### PR TITLE
Port to clang17 and C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,13 @@ enable_testing()
 set(CT_LLVM_INSTALL_DIR "/usr")
 
 # A bit of a sanity checking
-set(CT_LLVM_INCLUDE_DIR "${CT_LLVM_INSTALL_DIR}/include/llvm-14")
+set(CT_LLVM_INCLUDE_DIR "${CT_LLVM_INSTALL_DIR}/include/llvm-17")
 if(NOT EXISTS "${CT_LLVM_INCLUDE_DIR}")
 message(FATAL_ERROR
   " CT_LLVM_INSTALL_DIR (${CT_LLVM_INCLUDE_DIR}) is invalid.")
 endif()
 
-set(CT_LLVM_CMAKE_FILE "${CT_LLVM_INSTALL_DIR}/lib/cmake/clang-14/ClangConfig.cmake")
+set(CT_LLVM_CMAKE_FILE "${CT_LLVM_INSTALL_DIR}/lib/cmake/clang-17/ClangConfig.cmake")
 if(NOT EXISTS "${CT_LLVM_CMAKE_FILE}")
 message(FATAL_ERROR
   " CT_LLVM_CMAKE_FILE (${CT_LLVM_CMAKE_FILE}) is invalid.")
@@ -27,7 +27,7 @@ endif()
 # 2. LOAD CLANG CONFIGURATION
 #    For more: http://llvm.org/docs/CMake.html#embedding-llvm-in-your-project
 #===============================================================================
-set(CLANG_VERSION 14)
+set(CLANG_VERSION 17)
 list(APPEND CMAKE_PREFIX_PATH "${CT_LLVM_INSTALL_DIR}/lib/cmake/llvm-${CLANG_VERSION}/")
 list(APPEND CMAKE_PREFIX_PATH "${CT_LLVM_INSTALL_DIR}/lib/cmake/clang-${CLANG_VERSION}/")
 
@@ -57,7 +57,7 @@ include_directories(SYSTEM "${LLVM_INCLUDE_DIRS};${CLANG_INCLUDE_DIRS}")
 # 3. cpp2c BUILD CONFIGURATION
 #===============================================================================
 # Use the same C++ standard as LLVM does
-set(CMAKE_CXX_STANDARD 14 CACHE STRING "")
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
 
 # Build type
 if (NOT CMAKE_BUILD_TYPE)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This artifact enables you to reproduce this data on your own machine.
 
 ### Clang Plugin
 ```
-sudo apt install llvm-14 clang-14 libclang-14-dev build-essential cmake
+sudo apt install llvm-17 clang-17 libclang-17-dev build-essential cmake
 ```
 
 ### Python Script

--- a/src/Cpp2CASTConsumer.cc
+++ b/src/Cpp2CASTConsumer.cc
@@ -270,19 +270,19 @@ namespace cpp2c
     std::pair<bool, llvm::StringRef> isGlobalInclude(
         clang::SourceManager &SM,
         const clang::LangOptions &LO,
-        std::pair<const clang::FileEntry *, clang::SourceLocation> &IEL,
+        std::pair<clang::OptionalFileEntryRef, clang::SourceLocation> &IEL,
         std::set<llvm::StringRef> &LocalIncludes,
         std::vector<const clang::Decl *> &Decls)
     {
         auto FE = IEL.first;
         auto HashLoc = IEL.second;
 
-        // Check that the included file is not null
-        if (!FE)
+        // Check that the included file has a value
+        if (!FE.has_value())
             return {false, "<null>"};
 
         // Check that the included file actually has a name
-        auto IncludedFileRealpath = FE->tryGetRealPathName();
+        auto IncludedFileRealpath = FE->getFileEntry().tryGetRealPathName();
         if (IncludedFileRealpath.empty())
             return {false, IncludedFileRealpath};
 
@@ -334,8 +334,8 @@ namespace cpp2c
                     // that's fine since it would be a non-global
                     // location anyway
                     if (auto Tok = clang::Lexer::findNextToken(E, SM, LO))
-                        if (Tok.hasValue())
-                            E = SM.getFileLoc(Tok.getValue().getEndLoc());
+                        if (Tok.has_value())
+                            E = SM.getFileLoc(Tok.value().getEndLoc());
 
                     if (E.isInvalid())
                         return false;

--- a/src/IncludeCollector.cc
+++ b/src/IncludeCollector.cc
@@ -8,7 +8,7 @@ namespace cpp2c
         llvm::StringRef FileName,
         bool IsAngled,
         clang::CharSourceRange FilenameRange,
-        const clang::FileEntry *File,
+        clang::OptionalFileEntryRef File,
         llvm::StringRef SearchPath,
         llvm::StringRef RelativePath,
         const clang::Module *Imported,

--- a/src/IncludeCollector.hh
+++ b/src/IncludeCollector.hh
@@ -2,7 +2,7 @@
 
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
-#include "clang/Basic/FileManager.h"
+#include "clang/Basic/FileEntry.h"
 #include "clang/Basic/Module.h"
 #include "clang/Lex/PPCallbacks.h"
 #include "clang/Lex/Token.h"
@@ -17,7 +17,7 @@ namespace cpp2c
     class IncludeCollector : public clang::PPCallbacks
     {
     public:
-        std::vector<std::pair<const clang::FileEntry *, clang::SourceLocation>>
+        std::vector<std::pair<clang::OptionalFileEntryRef, clang::SourceLocation>>
             IncludeEntriesLocs;
 
         void InclusionDirective(
@@ -26,10 +26,10 @@ namespace cpp2c
             llvm::StringRef FileName,
             bool IsAngled,
             clang::CharSourceRange FilenameRange,
-            const clang::FileEntry *File,
+            clang::OptionalFileEntryRef File,
             llvm::StringRef SearchPath,
             llvm::StringRef RelativePath,
             const clang::Module *Imported,
             clang::SrcMgr::CharacteristicKind FileType) override;
     };
-} // namespace cpp2c
+} // namespace cpp2c 


### PR DESCRIPTION
These changes allow the clang plugin to be built and run with LLVM and Clang 17, and also configures the C++ standard to version 17.

Most of the changes were updating (possibly null) pointers to clang constructs to use optionals instead.