### PR TITLE
Add end definition location and function signature

### DIFF
--- a/src/Cpp2CASTConsumer.cc
+++ b/src/Cpp2CASTConsumer.cc
@@ -1034,6 +1034,8 @@ namespace cpp2c
                         // constant expression
                         IsExpansionICE = E->isIntegerConstantExpr(Ctx);
                     }
+                    // Macro identifier 
+                    TypeSignature += " " + Name;
 
                     // Argument type information
                     IsAnyArgumentNotAnExpression = false;
@@ -1087,6 +1089,7 @@ namespace cpp2c
                             hasTypeDefinedAfter(QT.getTypePtrOrNull(), Ctx, DefLoc);
 
                         TypeSignature += ArgTypeStr;
+                        TypeSignature += " " + Arg.Name.str();
                     }
                     debug("Finished iterating arguments");
                     if (Exp->MI->isFunctionLike() &&

--- a/src/Cpp2CASTConsumer.cc
+++ b/src/Cpp2CASTConsumer.cc
@@ -580,6 +580,7 @@ namespace cpp2c
             std::string
                 Name,
                 DefinitionLocation,
+                EndDefinitionLocation,
                 InvocationLocation,
                 ASTKind,
                 TypeSignature;
@@ -697,6 +698,10 @@ namespace cpp2c
             IsDefinitionLocationValid = Res.first;
             if (IsDefinitionLocationValid)
                 DefinitionLocation = Res.second;
+            auto [IsEndDefinitonLocationValid, EndLoc] = tryGetFullSourceLoc(SM, Exp->MI->getDefinitionEndLoc());
+            if(IsEndDefinitonLocationValid)
+                EndDefinitionLocation = EndLoc;
+                
 
             // Invocation location
             Res = tryGetFullSourceLoc(SM, Exp->SpellingRange.getBegin());
@@ -1126,6 +1131,7 @@ namespace cpp2c
                 {
                     {"Name", Name},
                     {"DefinitionLocation", DefinitionLocation},
+                    {"EndDefinitionLocation", EndDefinitionLocation},
                     {"InvocationLocation", InvocationLocation},
                     {"ASTKind", ASTKind},
                     {"TypeSignature", TypeSignature},


### PR DESCRIPTION
This PR adds an output field for the end definition location of the macro definition, as well as modifying the type signature to a proper function signature (containing identifiers for a function and it's arguments).

Note that this doesn't handle renaming functions, which will be necessary to handle multiple invocations of macros with different param types or return types.