### PR TITLE
Unify output as a JSON array w/ JSONPrinter class & emit body

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(cpp2c SHARED
   MacroExpansionArgument.cc
   MacroExpansionNode.cc
   StmtCollectorMatchHandler.cc
+  JSONPrinter.cc
 )
 
 # Allow undefined symbols in shared objects on Darwin (this is the default

--- a/src/Cpp2CASTConsumer.cc
+++ b/src/Cpp2CASTConsumer.cc
@@ -472,7 +472,6 @@ namespace cpp2c
                         {"IncludeName", IncludeName}
                     }
                 );
-                print("Include", Valid, IncludeName);
             }
         }
         debug("Finished checking includes");

--- a/src/Cpp2CASTConsumer.cc
+++ b/src/Cpp2CASTConsumer.cc
@@ -7,6 +7,7 @@
 #include "IncludeCollector.hh"
 #include "Logging.hh"
 #include "StmtCollectorMatchHandler.hh"
+#include "JSONPrinter.hh"
 
 #include "clang/Lex/Lexer.h"
 #include "clang/Lex/Preprocessor.h"
@@ -367,6 +368,9 @@ namespace cpp2c
         auto &SM = Ctx.getSourceManager();
         auto &LO = Ctx.getLangOpts();
 
+        // JSON printer for each invocation, definition, etc.
+        std::vector<JSONPrinter> printers;
+
         // Print definition information
         for (auto &&Entry : DC->MacroNamesDefinitions)
         {
@@ -386,8 +390,41 @@ namespace cpp2c
 
             auto MI = MD->getMacroInfo();
             assert(MI);
+            
+            std::string Body;
 
-            print("Definition", Name, MI->isObjectLike(), Valid, DefLocOrError);
+            /*
+            We could use 
+
+            Body = clang::Lexer::getSourceText(clang::CharSourceRange::getCharRange(Exp->DefinitionRange.getBegin(), Exp->DefinitionRange.getEnd().getLocWithOffset(1)), SM, LO).str();
+
+            to get the body of the macro expansion without a loop, but this lacks info for each token, we also don't need to preserve whitespace.
+            */
+
+            // If macro is a function, must have return statement
+            if (MI->isFunctionLike())
+                Body += "return ";
+
+            // Append the token to the body
+            for (auto& token : MI->tokens() ) {
+                Body += MF->PP.getSpelling(token);
+            } 
+
+            // End of body statement needs semicolon
+            Body += ";";
+
+            JSONPrinter printer{"Definition"};
+            printer.add(
+                {
+                    {"Name", Name},
+                    {"IsObjectLike", MI->isObjectLike()},
+                    {"IsValid", Valid},
+                    {"DefinitionLocationOrError", DefLocOrError},
+                    {"Body", Body}
+                }
+            );
+
+            printers.push_back(std::move(printer));
         }
 
         // Collect declaration ranges
@@ -405,8 +442,11 @@ namespace cpp2c
             });
 
         // Print names of macros inspected by the preprocessor
-        for (auto &&Name : DC->InspectedMacroNames)
-            print("InspectedByCPP", Name);
+        for (auto &&Name : DC->InspectedMacroNames) {
+            JSONPrinter printer{"InspectedByCPP"};
+            printer.add({{"Name", Name}});
+            printers.push_back(std::move(printer));
+        }
         // Print include-directive information
         {
             std::set<llvm::StringRef> LocalIncludes;
@@ -425,6 +465,13 @@ namespace cpp2c
                 Valid = Res.first;
                 IncludeName = Res.second.empty() ? "" : Res.second.str();
 
+                JSONPrinter printer{"Include"};
+                printer.add(
+                    {
+                        {"IsValid", Valid},
+                        {"IncludeName", IncludeName}
+                    }
+                );
                 print("Include", Valid, IncludeName);
             }
         }
@@ -1097,6 +1144,7 @@ namespace cpp2c
                         TypeSignature += ")";
                 }
 
+
                 // Set of all Stmts expanded from macro
                 std::set<const clang::Stmt *> AllStmtsExpandedFromMacro =
                     StmtsExpandedFromBody;
@@ -1115,22 +1163,9 @@ namespace cpp2c
                     });
             }
 
-            auto entryString = [](std::string k, std::string v) -> std::string
-            {
-                return "    \"" + k + "\" : \"" + v + "\"";
-            };
+            JSONPrinter printer{"Invocation"};
 
-            auto entryInt = [](std::string k, int v) -> std::string
-            {
-                return "    \"" + k + "\" : " + std::to_string(v);
-            };
-
-            auto entryBool = [](std::string k, bool v) -> std::string
-            {
-                return "    \"" + k + "\" : " + (v ? "true" : "false");
-            };
-
-            std::vector<std::pair<std::string, std::string>> stringEntries =
+            printer.add(
                 {
                     {"Name", Name},
                     {"DefinitionLocation", DefinitionLocation},
@@ -1138,16 +1173,18 @@ namespace cpp2c
                     {"InvocationLocation", InvocationLocation},
                     {"ASTKind", ASTKind},
                     {"TypeSignature", TypeSignature},
-                };
+                }
+            );
 
-            std::vector<std::pair<std::string, int>> intEntries =
+            printer.add(
                 {
                     {"InvocationDepth", InvocationDepth},
                     {"NumASTRoots", NumASTRoots},
                     {"NumArguments", NumArguments},
-                };
+                }
+            );
 
-            std::vector<std::pair<std::string, bool>> boolEntries =
+            printer.add(
                 {
                     {"HasStringification", HasStringification},
                     {"HasTokenPasting", HasTokenPasting},
@@ -1193,26 +1230,15 @@ namespace cpp2c
                     {"IsAnyArgumentExpandedWhereAddressableValueRequired", IsAnyArgumentExpandedWhereAddressableValueRequired},
                     {"IsAnyArgumentConditionallyEvaluated", IsAnyArgumentConditionallyEvaluated},
                     {"IsAnyArgumentNeverExpanded", IsAnyArgumentNeverExpanded},
-                    {"IsAnyArgumentNotAnExpression", IsAnyArgumentNotAnExpression},
-                };
+                    {"IsAnyArgumentNotAnExpression", IsAnyArgumentNotAnExpression}
+                }
+            );
 
-            // Only pretty print JSON if debug is on
-            const char sep = Debug ? '\n' : ' ';
 
-            llvm::outs() << "Invocation" << delim << '{' << sep;
-            for (auto &&e : stringEntries)
-                llvm::outs() << entryString(e.first, e.second) << "," << sep;
-            for (auto &&e : intEntries)
-                llvm::outs() << entryInt(e.first, e.second) << "," << sep;
-            for (size_t i = 0; i < boolEntries.size(); i++)
-            {
-                auto e = boolEntries[i];
-                llvm::outs() << entryBool(e.first, e.second)
-                             << (i == (boolEntries.size() - 1) ? "" : ",")
-                             << sep;
-            }
-            llvm::outs() << " }\n";
+            printers.push_back(std::move(printer));
         }
+        
+        cpp2c::JSONPrinter::printJSONArray(printers);
 
         // Only delete top level expansions since deconstructor deletes
         // nested expansions

--- a/src/JSONPrinter.cc
+++ b/src/JSONPrinter.cc
@@ -1,0 +1,62 @@
+#include "JSONPrinter.hh"
+
+namespace cpp2c {
+    JSONPrinter::JSONPrinter(std::string k) : kind(std::move(k)) {}
+
+
+    void JSONPrinter::add(std::initializer_list<std::pair<std::string, VariantType>> pairs) {
+        for(const auto& pair : pairs) {
+            data.emplace_back(pair);
+        }
+    }
+
+    void JSONPrinter::printJSONObject() const {
+
+        // Open json object
+        llvm::outs() << "{" << sep;
+
+        // Emit kind
+        llvm::outs() << generateJSONproperty("Kind", kind);
+
+        // Emit data
+        for(const auto& [key, value] : data) {
+            // Lambda must capture this for generateJSONproperty to work,
+            // and key must be captured by reference (cannot capture structured bindings before C++20)
+            std::visit([this, &key = key](const auto& value) {
+                llvm::outs() << ',' << sep << generateJSONproperty(key, value);
+            }, value);
+        }
+
+        // Close json object
+        llvm::outs() << sep << "}";
+    }
+
+    std::string JSONPrinter::generateJSONproperty(const std::string& key, const int& value) const {
+        return "    \"" + key + "\" : " + std::to_string(value);
+    }
+    std::string JSONPrinter::generateJSONproperty(const std::string& key, const bool& value) const {
+        return "    \"" + key + "\" : " + (value ? "true" : "false");
+    }
+    std::string JSONPrinter::generateJSONproperty(const std::string& key, const std::string& value) const {
+        return "    \"" + key + "\" : \"" + value + "\"";
+    }
+
+    void JSONPrinter::printJSONArray(std::vector<JSONPrinter>& printers) {
+        // Open json array
+        llvm::outs() << "[" << sep;
+
+        // Emit data
+        for(const auto& printer : printers) {
+            printer.printJSONObject();
+
+            // Add comma if not last element
+            if(&printer != &printers.back()) {
+                llvm::outs() << ',';
+            }
+            llvm::outs() << sep;
+        }
+
+        // Close json array
+        llvm::outs() << sep << "]\n";
+    }
+}

--- a/src/JSONPrinter.hh
+++ b/src/JSONPrinter.hh
@@ -1,0 +1,29 @@
+#pragma once
+#include "Logging.hh"
+
+#include <memory>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace cpp2c {
+    class JSONPrinter {
+        using VariantType = std::variant<int, bool, std::string>;
+        using KeyValuePair = std::pair<std::string, VariantType>;
+        private:
+            // Only pretty print JSON if debug is on
+            static const char sep = Debug ? '\n' : ' ';
+            std::string kind;
+            std::vector<KeyValuePair> data;
+        public:
+            JSONPrinter(std::string kind);
+
+            void add(std::initializer_list<std::pair<std::string, VariantType>> pairs);
+            void printJSONObject() const;
+            std::string generateJSONproperty(const std::string& key, const int& value) const;
+            std::string generateJSONproperty(const std::string& key, const bool& value) const;
+            std::string generateJSONproperty(const std::string& key, const std::string& value) const;
+
+            static void printJSONArray(std::vector<JSONPrinter>& printers);
+    };
+}

--- a/src/Logging.hh
+++ b/src/Logging.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <llvm/Support/raw_ostream.h>
 
 namespace cpp2c
 {


### PR DESCRIPTION
These changes unify the output of Maki as a single array of JSON objects containing a new property "Kind" which will represent if it was a Definition, Invocation, etc. This is done with the new JSONPrinter class.

In addition, the definition entries now emit the body of the macro.