### PR TITLE
Decay array types to pointers

### DIFF
--- a/src/Cpp2CASTConsumer.cc
+++ b/src/Cpp2CASTConsumer.cc
@@ -1129,6 +1129,12 @@ namespace cpp2c
                             auto CT = QT.getDesugaredType(Ctx)
                                           .getUnqualifiedType()
                                           .getCanonicalType();
+
+                            // If the argument is an array, decay to pointer
+                            if(CT->isArrayType()) {
+                                CT = Ctx.getArrayDecayedType(CT);
+                            }
+
                             ArgTypeStr = CT.getAsString();
                         }
                         IsAnyArgumentTypeDefinedAfterMacro |=


### PR DESCRIPTION
This change changes stack-allocated arrays in macro parameters to decay to pointers in the TypeSignature field.

i.e
```c
#include <stdio.h>
#include <string.h>
#define ZERO_OUT_ARRAY(ptr, size) memset(ptr, 0, sizeof(*(ptr)) * (size))

int main() {
    int arr[10];
    ZERO_OUT_ARRAY(arr, sizeof(arr) / sizeof(arr[0]));
}
```
Old:
```c
void * ZERO_OUT_ARRAY(int[10] ptr, unsigned long size)
```
New:
```c
void * ZERO_OUT_ARRAY(int * ptr, unsigned long size)
```