### PR TITLE
Decay arrays in type declarations to pointers

### DIFF
--- a/lib/MakiASTConsumer.cc
+++ b/lib/MakiASTConsumer.cc
@@ -920,7 +920,14 @@ void MakiASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
                         auto CT = QT.getDesugaredType(Ctx)
                                       .getUnqualifiedType()
                                       .getCanonicalType();
+
+                        // If the expansion is an array, decay to pointer
+                        if (CT->isArrayType()) {
+                            CT = Ctx.getArrayDecayedType(CT);
+                        }
+
                         TypeSignature = CT.getAsString();
+
                     }
                     IsExpansionTypeDefinedAfterMacro =
                         hasTypeDefinedAfter(QT.getTypePtrOrNull(), Ctx, DefLoc);


### PR DESCRIPTION
Small change to decay array types to pointers in a return or variable type within the TypeSignature. 

This will bring the behavior to align with the changes in #12, which only affected array types in function parameters.  