### PR TITLE
Code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cache
 .vscode
 build
+build.sh

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ The following instructions assume an Ubuntu 22.04.4 operating system:
 
 ## Setting up
 
-Run the script `build.sh` to build the Clang plugin:
+Build the Clang plugin, e.g.,
 
 ```bash
-bash build.sh
+cmake -S . -B build/ -G Ninja
+cmake --build build/
 ```
 
 ## Running the Clang Plugin
@@ -98,7 +99,8 @@ docker run -it maki:1.0
 Build the plugin:
 
 ```bash
-bash build.sh
+cmake -S . -B build/ -G Ninja
+cmake --build build/
 ```
 
 Run the test suite:

--- a/README.md
+++ b/README.md
@@ -84,21 +84,25 @@ script and `FileCheck` binary, respectively.
 ### Using the provided Docker image to test
 
 Build the Docker image with the following command in the project root:
+
 ```bash
 docker build -t maki:1.0 .
 ```
 
 Run the Docker image:
+
 ```bash
 docker run -it maki:1.0
 ```
 
 Build the plugin:
+
 ```bash
 bash build.sh
 ```
 
 Run the test suite:
+
 ```bash
 cmake -S . -B build/ \
     -DMAKI_ENABLE_TESTING=ON \

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,0 @@
-cmake -S . -B build -G Ninja
-cmake --build build --parallel

--- a/lib/ASTUtils.cc
+++ b/lib/ASTUtils.cc
@@ -1,17 +1,21 @@
 #include "ASTUtils.hh"
+#include <clang/AST/Stmt.h>
+#include <functional>
 
 namespace maki {
-bool isInTree(const clang::Stmt *ST,
+bool isInTree(const clang::Stmt *Stmt,
               std::function<bool(const clang::Stmt *)> pred) {
-    if (!ST)
+    if (!Stmt) {
         return false;
+    }
 
-    if (pred(ST))
+    if (pred(Stmt)) {
         return true;
+    }
 
-    for (auto &&child : ST->children())
-        if (isInTree(child, pred))
-            return true;
+    for (auto &&child : Stmt->children()) {
+        return isInTree(child, pred);
+    }
 
     return false;
 }

--- a/lib/ASTUtils.hh
+++ b/lib/ASTUtils.hh
@@ -1,10 +1,12 @@
 #pragma once
 
-#include "clang/AST/Stmt.h"
-
+#include <clang/AST/Stmt.h>
 #include <functional>
 
 namespace maki {
-bool isInTree(const clang::Stmt *ST,
+
+// Returns true if a Stmt that satisfies the given predicate is a subtree of the
+// given Stmt.
+bool isInTree(const clang::Stmt *Stmt,
               std::function<bool(const clang::Stmt *)> pred);
 } // namespace maki

--- a/lib/AlignmentMatchers.cc
+++ b/lib/AlignmentMatchers.cc
@@ -1,5 +1,9 @@
 #include "AlignmentMatchers.hh"
+#include "DeclStmtTypeLoc.hh"
 #include "ExpansionMatchHandler.hh"
+#include <clang/AST/ASTContext.h>
+#include <clang/ASTMatchers/ASTMatchersInternal.h>
+#include <vector>
 
 namespace maki {
 
@@ -8,24 +12,21 @@ void storeChildren(maki::DeclStmtTypeLoc DSTL,
                    std::set<const clang::Decl *> &MatchedDecls,
                    std::set<const clang::TypeLoc *> &MatchedTypeLocs) {
     if (DSTL.ST) {
+        // Traverse the Stmt tree using DFS
         std::stack<const clang::Stmt *> Descendants;
         Descendants.push(DSTL.ST);
         while (!Descendants.empty()) {
             auto Cur = Descendants.top();
             Descendants.pop();
-            if (!Cur)
-                continue;
-
-            // llvm::errs() << "Inserting:\n";
-            // Cur->dumpColor();
-            MatchedStmts.insert(Cur);
-            for (auto &&child : Cur->children())
-                if (child)
+            if (nullptr != Cur) {
+                MatchedStmts.insert(Cur);
+                for (auto &&child : Cur->children()) {
+                    // if (nullptr != child) /* child should not be null */
                     Descendants.push(child);
+                }
+            }
         }
     } else if (DSTL.D) {
-        // llvm::errs() << "Inserting:\n";
-        // DSTL.D->dump();
         MatchedDecls.insert(DSTL.D);
     }
     // else if (DSTL.TL)
@@ -44,92 +45,71 @@ void storeChildren(maki::DeclStmtTypeLoc DSTL,
     // }
 }
 
-void findAlignedASTNodesForExpansion(maki::MacroExpansionNode *Exp,
+template <typename T>
+std::vector<DeclStmtTypeLoc>
+matchNodes(clang::ast_matchers::internal::Matcher<T> Matcher,
+           clang::ASTContext &Ctx) {
+    MatchFinder Finder;
+    ExpansionMatchHandler MatchHandler;
+    Finder.addMatcher(Matcher, &MatchHandler);
+    Finder.matchAST(Ctx);
+    return MatchHandler.Matches;
+}
+
+void findAlignedASTNodesForExpansion(maki::MacroExpansionNode *Expansion,
                                      clang::ASTContext &Ctx) {
     using namespace clang::ast_matchers;
-    // Find AST nodes aligned with the entire invocation
+    // Find AST nodes aligned with the entire expansion.
 
     // Match stmts
-    {
-        MatchFinder Finder;
-        ExpansionMatchHandler Handler;
-        auto Matcher =
-            stmt(unless(anyOf(implicitCastExpr(), implicitValueInitExpr())),
-                 alignsWithExpansion(&Ctx, Exp))
-                .bind("root");
-        Finder.addMatcher(Matcher, &Handler);
-        Finder.matchAST(Ctx);
-        for (auto &&M : Handler.Matches)
-            Exp->ASTRoots.push_back(M);
-    }
+    auto StmtMatches = matchNodes(
+        stmt(unless(anyOf(implicitCastExpr(), implicitValueInitExpr())),
+             alignsWithExpansion(&Ctx, Expansion))
+            .bind("root"),
+        Ctx);
+    Expansion->ASTRoots.insert(Expansion->ASTRoots.end(), StmtMatches.begin(),
+                               StmtMatches.end());
 
     // Match decls
-    {
-        MatchFinder Finder;
-        ExpansionMatchHandler Handler;
-        auto Matcher = decl(alignsWithExpansion(&Ctx, Exp)).bind("root");
-        Finder.addMatcher(Matcher, &Handler);
-        Finder.matchAST(Ctx);
-        for (auto &&M : Handler.Matches)
-            Exp->ASTRoots.push_back(M);
-    }
+    auto DeclMatches = matchNodes(
+        decl(alignsWithExpansion(&Ctx, Expansion)).bind("root"), Ctx);
+    Expansion->ASTRoots.insert(Expansion->ASTRoots.end(), DeclMatches.begin(),
+                               DeclMatches.end());
 
     // Match type locs
-    {
-        MatchFinder Finder;
-        ExpansionMatchHandler Handler;
-        auto Matcher = typeLoc(alignsWithExpansion(&Ctx, (Exp))).bind("root");
-        Finder.addMatcher(Matcher, &Handler);
-        Finder.matchAST(Ctx);
-        for (auto &&M : Handler.Matches)
-            Exp->ASTRoots.push_back(M);
-    }
+    auto TypeLocMatches = matchNodes(
+        typeLoc(alignsWithExpansion(&Ctx, (Expansion))).bind("root"), Ctx);
+    Expansion->ASTRoots.insert(Expansion->ASTRoots.end(),
+                               TypeLocMatches.begin(), TypeLocMatches.end());
 
     // If the expansion only aligns with one node, then set this
     // as its aligned root
-    Exp->AlignedRoot =
-        (Exp->ASTRoots.size() == 1) ? (&(Exp->ASTRoots.front())) : nullptr;
+    if (1 == Expansion->ASTRoots.size()) {
+        Expansion->AlignedRoot = &Expansion->ASTRoots.front();
+    } else {
+        Expansion->AlignedRoot = nullptr;
+    }
 
     //// Find AST nodes aligned with each of the expansion's arguments
-
-    for (auto &&Arg : Exp->Arguments) {
+    for (auto &&Arg : Expansion->Arguments) {
         // Match stmts
-        {
-            MatchFinder Finder;
-            ExpansionMatchHandler Handler;
-            auto Matcher =
-                stmt(unless(anyOf(implicitCastExpr(), implicitValueInitExpr())),
-                     isSpelledFromTokens(&Ctx, Arg.Tokens))
-                    .bind("root");
-            Finder.addMatcher(Matcher, &Handler);
-            Finder.matchAST(Ctx);
-            for (auto &&M : Handler.Matches)
-                Arg.AlignedRoots.push_back(M);
-        }
-
+        auto StmtMatches = matchNodes(
+            stmt(unless(anyOf(implicitCastExpr(), implicitValueInitExpr())),
+                 isSpelledFromTokens(&Ctx, Arg.Tokens))
+                .bind("root"),
+            Ctx);
+        Arg.AlignedRoots.insert(Arg.AlignedRoots.end(), StmtMatches.begin(),
+                                StmtMatches.end());
         // Match decls
-        {
-            MatchFinder Finder;
-            ExpansionMatchHandler Handler;
-            auto Matcher =
-                decl(isSpelledFromTokens(&Ctx, Arg.Tokens)).bind("root");
-            Finder.addMatcher(Matcher, &Handler);
-            Finder.matchAST(Ctx);
-            for (auto &&M : Handler.Matches)
-                Arg.AlignedRoots.push_back(M);
-        }
+        auto DeclMatches = matchNodes(
+            decl(isSpelledFromTokens(&Ctx, Arg.Tokens)).bind("root"), Ctx);
+        Arg.AlignedRoots.insert(Arg.AlignedRoots.end(), DeclMatches.begin(),
+                                DeclMatches.end());
 
-        // Match type locs
-        {
-            MatchFinder Finder;
-            ExpansionMatchHandler Handler;
-            auto Matcher =
-                typeLoc(isSpelledFromTokens(&Ctx, Arg.Tokens)).bind("root");
-            Finder.addMatcher(Matcher, &Handler);
-            Finder.matchAST(Ctx);
-            for (auto &&M : Handler.Matches)
-                Arg.AlignedRoots.push_back(M);
-        }
+        auto TypeLocMatches = matchNodes(
+            typeLoc(isSpelledFromTokens(&Ctx, Arg.Tokens)).bind("root"), Ctx);
+        Arg.AlignedRoots.insert(Arg.AlignedRoots.end(), TypeLocMatches.begin(),
+                                TypeLocMatches.end());
     }
 }
 } // namespace maki

--- a/lib/DeclCollectorMatchHandler.cc
+++ b/lib/DeclCollectorMatchHandler.cc
@@ -1,11 +1,14 @@
 #include "DeclCollectorMatchHandler.hh"
+#include <cassert>
+#include <clang/AST/DeclBase.h>
 
 namespace maki {
 void DeclCollectorMatchHandler::run(
     const clang::ast_matchers::MatchFinder::MatchResult &Result) {
-    if (auto ST = Result.Nodes.getNodeAs<clang::Decl>("root"))
-        Decls.push_back(ST);
-    else
+    if (auto Decl = Result.Nodes.getNodeAs<clang::Decl>("root")) {
+        Decls.push_back(Decl);
+    } else {
         assert(!"Matched a non-Decl node");
+    }
 }
 } // namespace maki

--- a/lib/DeclCollectorMatchHandler.hh
+++ b/lib/DeclCollectorMatchHandler.hh
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "clang/AST/Decl.h"
-#include "clang/ASTMatchers/ASTMatchFinder.h"
-
+#include <clang/AST/DeclBase.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <vector>
 
 namespace maki {

--- a/lib/DeclStmtTypeLoc.cc
+++ b/lib/DeclStmtTypeLoc.cc
@@ -1,6 +1,9 @@
 #include "DeclStmtTypeLoc.hh"
-
 #include "assert.h"
+#include <clang/AST/DeclBase.h>
+#include <clang/AST/Stmt.h>
+#include <clang/AST/TypeLoc.h>
+#include <clang/Basic/SourceLocation.h>
 
 namespace maki {
 DeclStmtTypeLoc::DeclStmtTypeLoc(const clang::Decl *D)
@@ -19,29 +22,32 @@ inline void DeclStmtTypeLoc::assertOneNonNull() {
 
 void DeclStmtTypeLoc::dump() {
     assertOneNonNull();
-    if (D)
+    if (D) {
         D->dump();
-    else if (ST)
+    } else if (ST) {
         ST->dump();
-    else if (TL) {
+    } else if (TL) {
         auto QT = TL->getType();
-        if (!QT.isNull())
+        if (!QT.isNull()) {
             QT.dump();
-        else
+        } else {
             llvm::errs() << "<Null type>\n";
-    } else
+        }
+    } else {
         assert(!"No node to dump");
+    }
 }
 
 clang::SourceRange DeclStmtTypeLoc::getSourceRange() {
     assertOneNonNull();
-    if (D)
+    if (D) {
         return D->getSourceRange();
-    else if (ST)
+    } else if (ST) {
         return ST->getSourceRange();
-    else if (TL)
+    } else if (TL) {
         return TL->getSourceRange();
-    else
+    } else {
         assert(!"No node to dump");
+    }
 }
 } // namespace maki

--- a/lib/DeclStmtTypeLoc.hh
+++ b/lib/DeclStmtTypeLoc.hh
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "clang/AST/Decl.h"
-#include "clang/AST/Stmt.h"
-#include "clang/AST/TypeLoc.h"
+#include <clang/AST/DeclBase.h>
+#include <clang/AST/Stmt.h>
+#include <clang/AST/TypeLoc.h>
+#include <clang/Basic/SourceLocation.h>
 
 namespace maki {
 class DeclStmtTypeLoc {

--- a/lib/DefinitionInfoCollector.cc
+++ b/lib/DefinitionInfoCollector.cc
@@ -1,6 +1,7 @@
 #include "DefinitionInfoCollector.hh"
 #include <clang/AST/ASTContext.h>
 #include <clang/Basic/SourceLocation.h>
+#include <clang/Lex/Lexer.h>
 #include <clang/Lex/MacroInfo.h>
 #include <clang/Lex/Token.h>
 

--- a/lib/DefinitionInfoCollector.cc
+++ b/lib/DefinitionInfoCollector.cc
@@ -1,4 +1,8 @@
 #include "DefinitionInfoCollector.hh"
+#include <clang/AST/ASTContext.h>
+#include <clang/Basic/SourceLocation.h>
+#include <clang/Lex/MacroInfo.h>
+#include <clang/Lex/Token.h>
 
 namespace maki {
 

--- a/lib/DefinitionInfoCollector.hh
+++ b/lib/DefinitionInfoCollector.hh
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "clang/AST/ASTContext.h"
-#include "clang/Basic/SourceLocation.h"
-#include "clang/Basic/SourceManager.h"
-#include "clang/Lex/Lexer.h"
-#include "clang/Lex/MacroInfo.h"
-#include "clang/Lex/PPCallbacks.h"
-#include "clang/Lex/Token.h"
-
+#include <clang/AST/ASTContext.h>
+#include <clang/Basic/LangOptions.h>
+#include <clang/Basic/SourceLocation.h>
+#include <clang/Basic/SourceManager.h>
+#include <clang/Lex/MacroInfo.h>
+#include <clang/Lex/PPCallbacks.h>
+#include <clang/Lex/Token.h>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/lib/ExpansionMatchHandler.cc
+++ b/lib/ExpansionMatchHandler.cc
@@ -1,19 +1,21 @@
 #include "ExpansionMatchHandler.hh"
-
-#include "clang/AST/Expr.h"
-
-#include <assert.h>
+#include <cassert>
+#include <clang/AST/DeclBase.h>
+#include <clang/AST/Stmt.h>
+#include <clang/AST/TypeLoc.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
 
 namespace maki {
 void ExpansionMatchHandler::run(
     const clang::ast_matchers::MatchFinder::MatchResult &Result) {
-    if (const auto D = Result.Nodes.getNodeAs<clang::Decl>("root"))
+    if (const auto D = Result.Nodes.getNodeAs<clang::Decl>("root")) {
         Matches.push_back(DeclStmtTypeLoc(D));
-    else if (const auto ST = Result.Nodes.getNodeAs<clang::Stmt>("root"))
+    } else if (const auto ST = Result.Nodes.getNodeAs<clang::Stmt>("root")) {
         Matches.push_back(DeclStmtTypeLoc(ST));
-    else if (const auto TL = Result.Nodes.getNodeAs<clang::TypeLoc>("root"))
+    } else if (const auto TL = Result.Nodes.getNodeAs<clang::TypeLoc>("root")) {
         Matches.push_back(DeclStmtTypeLoc(TL));
-    else
+    } else {
         assert(!"Matched a node that was node a Decl/Stmt/TypeLoc");
+    }
 }
 } // namespace maki

--- a/lib/ExpansionMatchHandler.hh
+++ b/lib/ExpansionMatchHandler.hh
@@ -1,10 +1,7 @@
 #pragma once
 
 #include "DeclStmtTypeLoc.hh"
-#include "MacroExpansionNode.hh"
-
-#include "clang/ASTMatchers/ASTMatchFinder.h"
-
+#include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <vector>
 
 namespace maki {

--- a/lib/IncludeCollector.cc
+++ b/lib/IncludeCollector.cc
@@ -1,4 +1,10 @@
 #include "IncludeCollector.hh"
+#include <clang/Basic/FileEntry.h>
+#include <clang/Basic/Module.h>
+#include <clang/Basic/SourceLocation.h>
+#include <clang/Basic/SourceManager.h>
+#include <clang/Lex/Token.h>
+#include <llvm-17/llvm/ADT/StringRef.h>
 
 namespace maki {
 void IncludeCollector::InclusionDirective(

--- a/lib/IncludeCollector.hh
+++ b/lib/IncludeCollector.hh
@@ -1,14 +1,12 @@
 #pragma once
 
-#include "clang/Basic/FileEntry.h"
-#include "clang/Basic/Module.h"
-#include "clang/Basic/SourceLocation.h"
-#include "clang/Basic/SourceManager.h"
-#include "clang/Lex/PPCallbacks.h"
-#include "clang/Lex/Token.h"
-
-#include "llvm/ADT/StringRef.h"
-
+#include <clang/Basic/FileEntry.h>
+#include <clang/Basic/Module.h>
+#include <clang/Basic/SourceLocation.h>
+#include <clang/Basic/SourceManager.h>
+#include <clang/Lex/PPCallbacks.h>
+#include <clang/Lex/Token.h>
+#include <llvm-17/llvm/ADT/StringRef.h>
 #include <utility>
 #include <vector>
 

--- a/lib/JSONPrinter.cc
+++ b/lib/JSONPrinter.cc
@@ -1,6 +1,12 @@
 #include "JSONPrinter.hh"
+#include <initializer_list>
 #include <iomanip>
+#include <llvm-17/llvm/Support/raw_ostream.h>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
 
 namespace maki {
 JSONPrinter::JSONPrinter(std::string k)

--- a/lib/JSONPrinter.hh
+++ b/lib/JSONPrinter.hh
@@ -1,8 +1,9 @@
 #pragma once
-#include "Logging.hh"
 
-#include <memory>
+#include "Logging.hh"
+#include <initializer_list>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 

--- a/lib/Logging.hh
+++ b/lib/Logging.hh
@@ -1,5 +1,6 @@
 #pragma once
-#include <llvm/Support/raw_ostream.h>
+
+#include <llvm-17/llvm/Support/raw_ostream.h>
 #include <string>
 
 namespace maki {

--- a/lib/MacroExpansionArgument.cc
+++ b/lib/MacroExpansionArgument.cc
@@ -1,7 +1,9 @@
 #include "MacroExpansionArgument.hh"
-
-#include "clang/Basic/SourceManager.h"
-#include "clang/Lex/Lexer.h"
+#include <clang/Basic/LangOptions.h>
+#include <clang/Basic/SourceManager.h>
+#include <clang/Basic/TokenKinds.h>
+#include <clang/Lex/Lexer.h>
+#include <llvm-17/llvm/Support/raw_ostream.h>
 
 namespace maki {
 void MacroExpansionArgument::dumpASTInfo(llvm::raw_fd_ostream &OS,
@@ -16,11 +18,13 @@ void MacroExpansionArgument::dumpASTInfo(llvm::raw_fd_ostream &OS,
     }
 
     llvm::errs() << "Aligned roots for argument " << Name << ":\n";
-    if (!AlignedRoots.empty())
-        for (auto R : AlignedRoots)
+    if (!AlignedRoots.empty()) {
+        for (auto R : AlignedRoots) {
             R.dump();
-    else
+        }
+    } else {
         llvm::errs() << "None\n";
+    }
 }
 
 } // namespace maki

--- a/lib/MacroExpansionArgument.hh
+++ b/lib/MacroExpansionArgument.hh
@@ -1,12 +1,11 @@
 #pragma once
 
 #include "DeclStmtTypeLoc.hh"
-
-#include "clang/Basic/LangOptions.h"
-#include "clang/Basic/SourceManager.h"
-#include "clang/Lex/Token.h"
-#include "llvm/ADT/StringRef.h"
-
+#include <clang/Basic/LangOptions.h>
+#include <clang/Basic/SourceManager.h>
+#include <clang/Lex/Token.h>
+#include <llvm-17/llvm/ADT/StringRef.h>
+#include <llvm-17/llvm/Support/raw_ostream.h>
 #include <vector>
 
 namespace maki {

--- a/lib/MacroExpansionNode.cc
+++ b/lib/MacroExpansionNode.cc
@@ -1,21 +1,22 @@
 #include "MacroExpansionNode.hh"
-
-#include "clang/Basic/SourceManager.h"
-
-#include "assert.h"
-
+#include <clang/Basic/LangOptions.h>
+#include <clang/Basic/SourceManager.h>
+#include <llvm-17/llvm/Support/raw_ostream.h>
 #include <queue>
+#include <set>
 
 namespace maki {
 
 MacroExpansionNode::~MacroExpansionNode() {
-    for (auto &&Child : Children)
+    for (auto &&Child : Children) {
         delete Child;
+    }
 }
 
 static inline void printIndent(llvm::raw_fd_ostream &OS, unsigned int indent) {
-    for (unsigned int i = 0; i < indent; i++)
+    for (unsigned int i = 0; i < indent; i++) {
         OS << "\t";
+    }
 }
 
 void MacroExpansionNode::dumpMacroInfo(llvm::raw_fd_ostream &OS,
@@ -34,8 +35,9 @@ void MacroExpansionNode::dumpMacroInfo(llvm::raw_fd_ostream &OS,
         OS << Name << " ends with arg " << ArgDefEndsWith->Name << "\n";
     }
 
-    for (auto Child : Children)
+    for (auto Child : Children) {
         Child->dumpMacroInfo(OS, indent + 1);
+    }
 }
 
 void MacroExpansionNode::dumpASTInfo(llvm::raw_fd_ostream &OS,
@@ -44,35 +46,41 @@ void MacroExpansionNode::dumpASTInfo(llvm::raw_fd_ostream &OS,
     OS << "Top level expansion of " << Name << "\n";
 
     OS << "AST roots: \n";
-    for (auto &&Root : ASTRoots)
+    for (auto &&Root : ASTRoots) {
         Root.dump();
+    }
 
     OS << "Aligned root: \n";
-    if (AlignedRoot)
+    if (AlignedRoot) {
         AlignedRoot->dump();
-    else
+    } else {
         OS << "None\n";
+    }
 
-    if (!Arguments.empty())
-        for (auto &&Arg : Arguments)
+    if (!Arguments.empty()) {
+        for (auto &&Arg : Arguments) {
             Arg.dumpASTInfo(OS, SM, LO);
-    else
+        }
+    } else {
         OS << "No arguments\n";
+    }
 }
 
 std::set<MacroExpansionNode *> MacroExpansionNode::getDescendants() {
     std::set<MacroExpansionNode *> Desc;
     // Collect descendants using BFS
     std::queue<MacroExpansionNode *> Q;
-    for (auto &&Child : Children)
+    for (auto &&Child : Children) {
         Q.push(Child);
+    }
 
     while (!Q.empty()) {
         auto Cur = Q.front();
         Q.pop();
         Desc.insert(Cur);
-        for (auto &&Child : Cur->Children)
+        for (auto &&Child : Cur->Children) {
             Q.push(Child);
+        }
     }
 
     return Desc;

--- a/lib/MacroExpansionNode.hh
+++ b/lib/MacroExpansionNode.hh
@@ -2,15 +2,12 @@
 
 #include "DeclStmtTypeLoc.hh"
 #include "MacroExpansionArgument.hh"
-
-#include "clang/AST/Stmt.h"
-#include "clang/Basic/SourceLocation.h"
-#include "clang/Lex/MacroInfo.h"
-
-#include "llvm/ADT/StringRef.h"
-#include "llvm/Support/raw_ostream.h"
-
+#include <clang/Basic/SourceLocation.h>
+#include <clang/Lex/MacroInfo.h>
+#include <clang/Lex/Token.h>
+#include <llvm-17/llvm/ADT/StringRef.h>
 #include <set>
+#include <string>
 #include <vector>
 
 namespace maki {

--- a/lib/MacroForest.hh
+++ b/lib/MacroForest.hh
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "MacroExpansionNode.hh"
-
-#include "clang/AST/ASTContext.h"
-#include "clang/Lex/PPCallbacks.h"
-
-#include <stack>
+#include <clang/AST/ASTContext.h>
+#include <clang/Basic/SourceLocation.h>
+#include <clang/Lex/MacroArgs.h>
+#include <clang/Lex/MacroInfo.h>
+#include <clang/Lex/PPCallbacks.h>
+#include <clang/Lex/Preprocessor.h>
+#include <clang/Lex/Token.h>
 #include <vector>
 
 namespace maki {
@@ -18,10 +20,9 @@ public:
     // Whether or not the current expansion is within a macro argument
     bool InMacroArg = false;
 
-    // The stack of previous expansions.
-    // The invocations in this stack should only ever be previous
-    // siblings of the current invocation, or the parent invocation
-    // of the current invocation.
+    // The stack of previous expansions. The invocations in this stack should
+    // only ever be previous siblings of the current invocation, or the parent
+    // invocation of the current invocation.
     std::stack<maki::MacroExpansionNode *> InvocationStack;
 
     MacroForest(clang::Preprocessor &PP, clang::ASTContext &Ctx);

--- a/lib/MakiASTConsumer.hh
+++ b/lib/MakiASTConsumer.hh
@@ -3,9 +3,11 @@
 #include "DefinitionInfoCollector.hh"
 #include "IncludeCollector.hh"
 #include "MacroForest.hh"
-
-#include "clang/Frontend/ASTConsumers.h"
-#include "clang/Frontend/CompilerInstance.h"
+#include <clang/AST/ASTConsumer.h>
+#include <clang/AST/ASTContext.h>
+#include <clang/AST/Stmt.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <llvm-17/llvm/Support/Casting.h>
 
 namespace maki {
 class MakiASTConsumer : public clang::ASTConsumer {

--- a/lib/MakiAction.cc
+++ b/lib/MakiAction.cc
@@ -1,5 +1,10 @@
 #include "MakiAction.hh"
 #include "MakiASTConsumer.hh"
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Frontend/FrontendPluginRegistry.h>
+#include <llvm-17/llvm/ADT/StringRef.h>
+#include <string>
 
 namespace maki {
 std::unique_ptr<clang::ASTConsumer>

--- a/lib/MakiAction.hh
+++ b/lib/MakiAction.hh
@@ -1,6 +1,12 @@
 #pragma once
 
-#include <clang/Frontend/FrontendPluginRegistry.h>
+#include <clang/AST/ASTConsumer.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/FrontendAction.h>
+#include <llvm-17/llvm/ADT/StringRef.h>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace maki {
 class MakiAction : public clang::PluginASTAction {

--- a/lib/StmtCollectorMatchHandler.cc
+++ b/lib/StmtCollectorMatchHandler.cc
@@ -1,11 +1,14 @@
 #include "StmtCollectorMatchHandler.hh"
+#include <clang/AST/Stmt.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
 
 namespace maki {
 void StmtCollectorMatchHandler::run(
     const clang::ast_matchers::MatchFinder::MatchResult &Result) {
-    if (auto ST = Result.Nodes.getNodeAs<clang::Stmt>("root"))
+    if (auto ST = Result.Nodes.getNodeAs<clang::Stmt>("root")) {
         Stmts.insert(ST);
-    else
+    } else {
         assert(!"Matched a non-Stmt node");
+    }
 }
 } // namespace maki

--- a/lib/StmtCollectorMatchHandler.hh
+++ b/lib/StmtCollectorMatchHandler.hh
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "clang/AST/Stmt.h"
-#include "clang/ASTMatchers/ASTMatchFinder.h"
-
+#include <clang/AST/Stmt.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <set>
 
 namespace maki {


### PR DESCRIPTION
- Review each files list of includes. Sort each list of includes, add missing includes, update LLVM includes to LLVM 17, and remove unused includes.
- Rewrap comments to 80 column limit.
- Change some variable names to be more descriptive.
- Use curly braces around control flow branches (e.g., if/then/else branches).