### PR TITLE
Fix modified argument checks

### DIFF
--- a/test/Tests/bc_modified_arguments.c
+++ b/test/Tests/bc_modified_arguments.c
@@ -1,0 +1,151 @@
+// RUN: maki %s -fplugin-arg-maki---no-system-macros -fplugin-arg-maki---no-builtin-macros -fplugin-arg-maki---no-invalid-macros | jq 'sort_by(.Kind, .DefinitionLocation, .InvocationLocation)' | FileCheck %s --color
+
+// COM: Taken from https://github.com/gavinhoward/bc
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#define restrict __restrict
+
+typedef int_least32_t BcDig;
+
+typedef struct BcNum {
+    BcDig *restrict num;
+
+    size_t rdx;
+
+    size_t scale;
+
+    size_t len;
+
+    size_t cap;
+
+} BcNum;
+
+typedef uint32_t BclBigDig;
+typedef BclBigDig BcBigDig;
+
+#define BC_NUM_NEG_TGL_NP(n) ((n).rdx ^= ((BcBigDig)1))
+
+int main(void) {
+    BcNum n;
+    BC_NUM_NEG_TGL_NP(n);
+    return 0;
+}
+
+// CHECK: [
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "BC_NUM_NEG_TGL_NP",
+// CHECK:     "IsObjectLike": false,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "( ( n ) . rdx ^= ( ( BcBigDig ) 1 ) )",
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/bc_modified_arguments.c:28:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/bc_modified_arguments.c:28:55"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "restrict",
+// CHECK:     "IsObjectLike": true,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "__restrict",
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/bc_modified_arguments.c:8:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/bc_modified_arguments.c:8:18"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Invocation",
+// CHECK:     "Name": "BC_NUM_NEG_TGL_NP",
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/bc_modified_arguments.c:28:9",
+// CHECK:     "InvocationLocation": "{{.*}}/Tests/bc_modified_arguments.c:32:5",
+// CHECK:     "ASTKind": "Expr",
+// CHECK:     "TypeSignature": "unsigned long BC_NUM_NEG_TGL_NP(struct BcNum n)",
+// CHECK:     "InvocationDepth": 0,
+// CHECK:     "NumASTRoots": 1,
+// CHECK:     "NumArguments": 1,
+// CHECK:     "HasStringification": false,
+// CHECK:     "HasTokenPasting": false,
+// CHECK:     "HasAlignedArguments": true,
+// CHECK:     "HasSameNameAsOtherDeclaration": false,
+// CHECK:     "IsExpansionControlFlowStmt": false,
+// CHECK:     "DoesBodyReferenceMacroDefinedAfterMacro": false,
+// CHECK:     "DoesBodyReferenceDeclDeclaredAfterMacro": false,
+// CHECK:     "DoesBodyContainDeclRefExpr": false,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveLocalType": false,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveTypeDefinedAfterMacro": false,
+// CHECK:     "DoesAnyArgumentHaveSideEffects": false,
+// CHECK:     "DoesAnyArgumentContainDeclRefExpr": true,
+// CHECK:     "IsHygienic": true,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "IsInvocationLocationValid": true,
+// CHECK:     "IsObjectLike": false,
+// CHECK:     "IsInvokedInMacroArgument": false,
+// CHECK:     "IsNamePresentInCPPConditional": false,
+// CHECK:     "IsExpansionICE": false,
+// CHECK:     "IsExpansionTypeNull": false,
+// CHECK:     "IsExpansionTypeAnonymous": false,
+// CHECK:     "IsExpansionTypeLocalType": false,
+// CHECK:     "IsExpansionTypeDefinedAfterMacro": false,
+// CHECK:     "IsExpansionTypeVoid": false,
+// CHECK:     "IsAnyArgumentTypeNull": false,
+// CHECK:     "IsAnyArgumentTypeAnonymous": false,
+// CHECK:     "IsAnyArgumentTypeLocalType": false,
+// CHECK:     "IsAnyArgumentTypeDefinedAfterMacro": false,
+// CHECK:     "IsAnyArgumentTypeVoid": false,
+// CHECK:     "IsInvokedWhereModifiableValueRequired": false,
+// CHECK:     "IsInvokedWhereAddressableValueRequired": false,
+// CHECK:     "IsInvokedWhereICERequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereModifiableValueRequired": true,
+// CHECK:     "IsAnyArgumentExpandedWhereAddressableValueRequired": false,
+// CHECK:     "IsAnyArgumentConditionallyEvaluated": false,
+// CHECK:     "IsAnyArgumentNeverExpanded": false,
+// CHECK:     "IsAnyArgumentNotAnExpression": false
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Invocation",
+// CHECK:     "Name": "restrict",
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/bc_modified_arguments.c:8:9",
+// CHECK:     "InvocationLocation": "{{.*}}/Tests/bc_modified_arguments.c:13:12",
+// CHECK:     "ASTKind": "",
+// CHECK:     "TypeSignature": "",
+// CHECK:     "InvocationDepth": 0,
+// CHECK:     "NumASTRoots": 0,
+// CHECK:     "NumArguments": 0,
+// CHECK:     "HasStringification": false,
+// CHECK:     "HasTokenPasting": false,
+// CHECK:     "HasAlignedArguments": true,
+// CHECK:     "HasSameNameAsOtherDeclaration": false,
+// CHECK:     "IsExpansionControlFlowStmt": false,
+// CHECK:     "DoesBodyReferenceMacroDefinedAfterMacro": false,
+// CHECK:     "DoesBodyReferenceDeclDeclaredAfterMacro": false,
+// CHECK:     "DoesBodyContainDeclRefExpr": false,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveLocalType": false,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveTypeDefinedAfterMacro": false,
+// CHECK:     "DoesAnyArgumentHaveSideEffects": false,
+// CHECK:     "DoesAnyArgumentContainDeclRefExpr": false,
+// CHECK:     "IsHygienic": false,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "IsInvocationLocationValid": true,
+// CHECK:     "IsObjectLike": true,
+// CHECK:     "IsInvokedInMacroArgument": false,
+// CHECK:     "IsNamePresentInCPPConditional": false,
+// CHECK:     "IsExpansionICE": false,
+// CHECK:     "IsExpansionTypeNull": false,
+// CHECK:     "IsExpansionTypeAnonymous": false,
+// CHECK:     "IsExpansionTypeLocalType": false,
+// CHECK:     "IsExpansionTypeDefinedAfterMacro": false,
+// CHECK:     "IsExpansionTypeVoid": false,
+// CHECK:     "IsAnyArgumentTypeNull": false,
+// CHECK:     "IsAnyArgumentTypeAnonymous": false,
+// CHECK:     "IsAnyArgumentTypeLocalType": false,
+// CHECK:     "IsAnyArgumentTypeDefinedAfterMacro": false,
+// CHECK:     "IsAnyArgumentTypeVoid": false,
+// CHECK:     "IsInvokedWhereModifiableValueRequired": false,
+// CHECK:     "IsInvokedWhereAddressableValueRequired": false,
+// CHECK:     "IsInvokedWhereICERequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereModifiableValueRequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereAddressableValueRequired": false,
+// CHECK:     "IsAnyArgumentConditionallyEvaluated": false,
+// CHECK:     "IsAnyArgumentNeverExpanded": false,
+// CHECK:     "IsAnyArgumentNotAnExpression": false
+// CHECK:   }
+// CHECK: ]


### PR DESCRIPTION
Makes checks for modified macro arguments more conservative by returning true if a modified argument appears in the subtree of a side-effecting expression, instead of only checking if a macro argument is a side-effected expression.

Closes #33 