### PR TITLE
Add property `IsDefinedAtGlobalScope` to macro definitions

### DIFF
--- a/lib/MakiASTConsumer.cc
+++ b/lib/MakiASTConsumer.cc
@@ -328,6 +328,52 @@ std::pair<bool, llvm::StringRef> isGlobalInclude(
     return { true, IncludedFileRealpath };
 }
 
+// Checks if the given location is within the declaration range of any of the
+// given declarations, either directly or by being #include'd at a local scope.
+bool isLocationInAnyDecl(clang::SourceManager &SM, const clang::LangOptions &LO,
+                         clang::SourceLocation Location,
+                         std::vector<const clang::Decl *> &Decls) {
+    std::vector<clang::SourceLocation> LocationsToCheck;
+    // Get all the locations that this location was #include'd from, if any.
+    for (auto FileID = SM.getFileID(Location); Location.isValid();
+         Location = SM.getIncludeLoc(FileID), FileID = SM.getFileID(Location)) {
+        LocationsToCheck.push_back(Location);
+    }
+
+    // For all locations to check...
+    return std::all_of(
+        LocationsToCheck.begin(), LocationsToCheck.end(),
+        [&SM, &LO, &Decls](clang::SourceLocation Loc) {
+            // ..check if the location appears in the source range of any of the
+            // given declarations.
+            return !std::any_of(
+                Decls.begin(), Decls.end(),
+                [&SM, &LO, &Loc](const clang::Decl *D) {
+                    auto B = SM.getFileLoc(D->getBeginLoc());
+                    auto E = SM.getFileLoc(D->getEndLoc());
+
+                    if (B.isInvalid() || E.isInvalid()) {
+                        return false;
+                    }
+
+                    // If this decl is not for a function, then extend the range
+                    // to include the location just after the declaration to
+                    // account for semicolons.
+                    if (!clang::isa<clang::FunctionDecl>(D)) {
+                        if (auto Tok = clang::Lexer::findNextToken(E, SM, LO)) {
+                            E = SM.getFileLoc(Tok->getEndLoc());
+                        }
+                    }
+
+                    if (E.isInvalid()) {
+                        return false;
+                    }
+
+                    return clang::SourceRange(B, E).fullyContains(Loc);
+                });
+        });
+}
+
 MakiASTConsumer::MakiASTConsumer(clang::CompilerInstance &CI,
                                  MakiFlags Flags_) {
     clang::Preprocessor &PP = CI.getPreprocessor();
@@ -350,6 +396,17 @@ void MakiASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
     // JSON printer for each invocation, definition, etc.
     std::vector<JSONPrinter> printers;
 
+    // Collect all declarations
+    std::vector<const clang::Decl *> AllDecls = ({
+        MatchFinder Finder;
+        DeclCollectorMatchHandler Handler;
+        auto Matcher = decl(unless(anyOf(isImplicit(), translationUnitDecl())))
+                           .bind("root");
+        Finder.addMatcher(Matcher, &Handler);
+        Finder.matchAST(Ctx);
+        Handler.Decls;
+    });
+
     // Print definition information
     for (auto &&Entry : DC->MacroNamesDefinitions) {
         // String properties
@@ -359,6 +416,7 @@ void MakiASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
         std::string Name = Entry.first;
 
         // Boolean properties
+        bool IsDefinedAtGlobalScope = false;
         bool IsDefinitionLocationValid = false;
 
         auto MD = Entry.second;
@@ -381,34 +439,28 @@ void MakiASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
             first = false;
         }
 
+        auto DefLoc = MI->getDefinitionLoc();
+
+        IsDefinedAtGlobalScope = isLocationInAnyDecl(SM, LO, DefLoc, AllDecls);
+
         std::tie(IsDefinitionLocationValid, DefinitionLocation) =
-            tryGetFullSourceLoc(SM, MI->getDefinitionLoc());
+            tryGetFullSourceLoc(SM, DefLoc);
         std::tie(std::ignore, EndDefinitionLocation) =
             tryGetFullSourceLoc(SM, MI->getDefinitionEndLoc());
 
         JSONPrinter printer{ "Definition" };
         printer.add({
+            { "Name", Name },
+            { "IsObjectLike", MI->isObjectLike() },
+            { "IsDefinitionLocationValid", IsDefinitionLocationValid },
             { "Body", Body },
+            { "IsDefinedAtGlobalScope", IsDefinedAtGlobalScope },
             { "DefinitionLocation", DefinitionLocation },
             { "EndDefinitionLocation", EndDefinitionLocation },
-            { "IsDefinitionLocationValid", IsDefinitionLocationValid },
-            { "IsObjectLike", MI->isObjectLike() },
-            { "Name", Name },
         });
 
         printers.push_back(std::move(printer));
     }
-
-    // Collect declaration ranges
-    std::vector<const clang::Decl *> TopLevelDecls = ({
-        MatchFinder Finder;
-        DeclCollectorMatchHandler Handler;
-        auto Matcher = decl(unless(anyOf(isImplicit(), translationUnitDecl())))
-                           .bind("root");
-        Finder.addMatcher(Matcher, &Handler);
-        Finder.matchAST(Ctx);
-        Handler.Decls;
-    });
 
     // Print names of macros inspected by the preprocessor
     for (auto &&Name : DC->InspectedMacroNames) {
@@ -425,8 +477,7 @@ void MakiASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
             std::string IncludeName = "";
 
             // Check if included at global scope or not
-            auto Res =
-                isGlobalInclude(SM, LO, IEL, LocalIncludes, TopLevelDecls);
+            auto Res = isGlobalInclude(SM, LO, IEL, LocalIncludes, AllDecls);
             if (!Res.first) {
                 LocalIncludes.insert(Res.second);
             }
@@ -648,7 +699,7 @@ void MakiASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
             // Also check if any global declarations defined before this macro
             // have the same name as this macro
             std::any_of(
-                TopLevelDecls.begin(), TopLevelDecls.end(),
+                AllDecls.begin(), AllDecls.end(),
                 [&SM, &Exp](const clang::Decl *D) {
                     auto ND = clang::dyn_cast_or_null<clang::NamedDecl>(D);
                     if (!ND) {

--- a/test/Tests/define_at_non_global_scope.c
+++ b/test/Tests/define_at_non_global_scope.c
@@ -21,6 +21,14 @@ int main(void) {
 }
 #define FIVE 5
 
+struct A {
+    int a;
+    int b;
+// Declared inside struct. Direction translation to variable or enum will break
+// program.
+#define C 10
+};
+
 // COM: This separate definition of EIGHT is at the global scope
 #include "eight.h"
 
@@ -55,6 +63,16 @@ int main(void) {
 // CHECK:     "IsDefinedAtGlobalScope": true,
 // CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:22:9",
 // CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:22:14"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "C",
+// CHECK:     "IsObjectLike": true,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "10",
+// CHECK:     "IsDefinedAtGlobalScope": false,
+// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:29:9",
+// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:29:11"
 // CHECK:   },
 // CHECK:   {
 // CHECK:     "Kind": "Definition",

--- a/test/Tests/define_at_non_global_scope.c
+++ b/test/Tests/define_at_non_global_scope.c
@@ -41,8 +41,8 @@ struct A {
 // CHECK:     "IsDefinitionLocationValid": true,
 // CHECK:     "Body": "3",
 // CHECK:     "IsDefinedAtGlobalScope": false,
-// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:15:9",
-// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:15:15"
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:15:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:15:15"
 // CHECK:   },
 // CHECK:   {
 // CHECK:     "Kind": "Definition",
@@ -51,8 +51,8 @@ struct A {
 // CHECK:     "IsDefinitionLocationValid": true,
 // CHECK:     "Body": "4",
 // CHECK:     "IsDefinedAtGlobalScope": false,
-// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:19:9",
-// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:19:14"
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:19:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:19:14"
 // CHECK:   },
 // CHECK:   {
 // CHECK:     "Kind": "Definition",
@@ -61,8 +61,8 @@ struct A {
 // CHECK:     "IsDefinitionLocationValid": true,
 // CHECK:     "Body": "5",
 // CHECK:     "IsDefinedAtGlobalScope": true,
-// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:22:9",
-// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:22:14"
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:22:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:22:14"
 // CHECK:   },
 // CHECK:   {
 // CHECK:     "Kind": "Definition",
@@ -71,8 +71,8 @@ struct A {
 // CHECK:     "IsDefinitionLocationValid": true,
 // CHECK:     "Body": "10",
 // CHECK:     "IsDefinedAtGlobalScope": false,
-// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:29:9",
-// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:29:11"
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:29:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:29:11"
 // CHECK:   },
 // CHECK:   {
 // CHECK:     "Kind": "Definition",
@@ -81,8 +81,8 @@ struct A {
 // CHECK:     "IsDefinitionLocationValid": true,
 // CHECK:     "Body": "0",
 // CHECK:     "IsDefinedAtGlobalScope": true,
-// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:3:9",
-// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:3:14"
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:3:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:3:14"
 // CHECK:   },
 // CHECK:   {
 // CHECK:     "Kind": "Definition",
@@ -91,8 +91,8 @@ struct A {
 // CHECK:     "IsDefinitionLocationValid": true,
 // CHECK:     "Body": "1",
 // CHECK:     "IsDefinedAtGlobalScope": false,
-// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:5:9",
-// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:5:13"
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:5:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:5:13"
 // CHECK:   },
 // CHECK:   {
 // CHECK:     "Kind": "Definition",
@@ -101,8 +101,8 @@ struct A {
 // CHECK:     "IsDefinitionLocationValid": true,
 // CHECK:     "Body": "2",
 // CHECK:     "IsDefinedAtGlobalScope": false,
-// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:9:9",
-// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:9:13"
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:9:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/define_at_non_global_scope.c:9:13"
 // CHECK:   },
 // CHECK:   {
 // CHECK:     "Kind": "Definition",
@@ -111,8 +111,8 @@ struct A {
 // CHECK:     "IsDefinitionLocationValid": true,
 // CHECK:     "Body": "8",
 // CHECK:     "IsDefinedAtGlobalScope": false,
-// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/eight.h:2:9",
-// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/eight.h:2:15"
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/eight.h:2:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/eight.h:2:15"
 // CHECK:   },
 // CHECK:   {
 // CHECK:     "Kind": "Definition",
@@ -121,7 +121,7 @@ struct A {
 // CHECK:     "IsDefinitionLocationValid": true,
 // CHECK:     "Body": "8",
 // CHECK:     "IsDefinedAtGlobalScope": true,
-// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/eight.h:2:9",
-// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/eight.h:2:15"
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/eight.h:2:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/eight.h:2:15"
 // CHECK:   }
 // CHECK: ]

--- a/test/Tests/define_at_non_global_scope.c
+++ b/test/Tests/define_at_non_global_scope.c
@@ -1,0 +1,109 @@
+// RUN: maki %s -fplugin-arg-maki---no-system-macros -fplugin-arg-maki---no-builtin-macros -fplugin-arg-maki---no-invalid-macros | jq 'sort_by(.Kind, .DefinitionLocation, .InvocationLocation)' | FileCheck %s --color
+
+#define ZERO 0
+typedef struct foo {
+#define ONE 1
+} foo;
+
+typedef union bar {
+#define TWO 2
+// COM: This #include'd definition of EIGHT is not at the global scope
+#include "eight.h"
+} bar;
+
+int baz =
+#define THREE 3
+    0;
+
+int main(void) {
+#define FOUR 4
+    return 0;
+}
+#define FIVE 5
+
+// COM: This separate definition of EIGHT is at the global scope
+#include "eight.h"
+
+
+// CHECK: [
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "THREE",
+// CHECK:     "IsObjectLike": true,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "3",
+// CHECK:     "IsDefinedAtGlobalScope": false,
+// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:15:9",
+// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:15:15"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "FOUR",
+// CHECK:     "IsObjectLike": true,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "4",
+// CHECK:     "IsDefinedAtGlobalScope": false,
+// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:19:9",
+// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:19:14"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "FIVE",
+// CHECK:     "IsObjectLike": true,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "5",
+// CHECK:     "IsDefinedAtGlobalScope": true,
+// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:22:9",
+// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:22:14"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "ZERO",
+// CHECK:     "IsObjectLike": true,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "0",
+// CHECK:     "IsDefinedAtGlobalScope": true,
+// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:3:9",
+// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:3:14"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "ONE",
+// CHECK:     "IsObjectLike": true,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "1",
+// CHECK:     "IsDefinedAtGlobalScope": false,
+// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:5:9",
+// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:5:13"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "TWO",
+// CHECK:     "IsObjectLike": true,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "2",
+// CHECK:     "IsDefinedAtGlobalScope": false,
+// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:9:9",
+// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/define_at_non_global_scope.c:9:13"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "EIGHT",
+// CHECK:     "IsObjectLike": true,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "8",
+// CHECK:     "IsDefinedAtGlobalScope": false,
+// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/eight.h:2:9",
+// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/eight.h:2:15"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "EIGHT",
+// CHECK:     "IsObjectLike": true,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "8",
+// CHECK:     "IsDefinedAtGlobalScope": true,
+// CHECK:     "DefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/eight.h:2:9",
+// CHECK:     "EndDefinitionLocation": "/home/bpappas/github.com/appleseedlab/maki/test/Tests/eight.h:2:15"
+// CHECK:   }
+// CHECK: ]


### PR DESCRIPTION
Adds the property `IsDefinedAtGlobalScope` to macro definitions so consumers of Maki can tell if a macro definition can be safely replaced with a global C language construct.

Closes #38 