### PR TITLE
Fix clang assertion failure in getting type of sizeof/cast expression 

### DIFF
--- a/lib/MakiASTConsumer.cc
+++ b/lib/MakiASTConsumer.cc
@@ -939,7 +939,7 @@ void MakiASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
                             // this macro.
                             if (auto CastOrSizeOf = clang::dyn_cast<
                                     clang::UnaryExprOrTypeTraitExpr>(St)) {
-                                auto T = CastOrSizeOf->getArgumentType()
+                                auto T = CastOrSizeOf->getTypeOfArgument()
                                              .getTypePtrOrNull();
                                 return hasTypeDefinedAfter(T, Ctx, DefLoc);
                             }


### PR DESCRIPTION
In the definition of `DoesSubexpressionExpandedFromBodyHaveTypeDefinedAfterMacro`, `getArgumentType` is called after a statement is cast to `UnaryExprOrTypeTraitExpr`. If the type of the statement is an expr and not an argument, this will trigger an assertion and crash clang, as seen when analyzing certain parts of bash:
```
clang-17: /usr/lib/llvm-17/include/clang/AST/Expr.h:2626: clang::TypeSourceInfo* clang::UnaryExprOrTypeTraitExpr::getArgumentTypeInfo() const: Assertion `isArgumentType() && "calling getArgumentType() when arg is expr"' failed.
```

Calling `UnaryExprOrTypeTraitExpr::getTypeOfArgument` instead handles this difference and calls the appropriate function, and fixes this crash. 

```cpp
  /// Gets the argument type, or the type of the argument expression, whichever
  /// is appropriate.
  QualType getTypeOfArgument() const {
    return isArgumentType() ? getArgumentType() : getArgumentExpr()->getType();
  }

```