### PR TITLE
Fix `IsAnyArgument` property checks

### DIFF
--- a/lib/MakiASTConsumer.cc
+++ b/lib/MakiASTConsumer.cc
@@ -1156,9 +1156,9 @@ void MakiASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
                     IsAnyArgumentTypeNull |= QT.isNull() || T == nullptr;
 
                     if (T) {
-                        IsAnyArgumentTypeVoid = T->isVoidType();
-                        IsAnyArgumentTypeAnonymous = hasAnonymousType(T, Ctx);
-                        IsAnyArgumentTypeLocalType = hasLocalType(T, Ctx);
+                        IsAnyArgumentTypeVoid |= T->isVoidType();
+                        IsAnyArgumentTypeAnonymous |= hasAnonymousType(T, Ctx);
+                        IsAnyArgumentTypeLocalType |= hasLocalType(T, Ctx);
                         auto CT = QT.getDesugaredType(Ctx)
                                       .getUnqualifiedType()
                                       .getCanonicalType();

--- a/test/Tests/is_any_argument_void.c
+++ b/test/Tests/is_any_argument_void.c
@@ -1,0 +1,78 @@
+// RUN: maki %s -fplugin-arg-maki---no-system-macros -fplugin-arg-maki---no-builtin-macros -fplugin-arg-maki---no-invalid-macros | jq 'sort_by(.Kind, .DefinitionLocation, .InvocationLocation)' | FileCheck %s --color
+
+#define FOO(A, B) ((A), (B))
+
+void bar(void) {
+}
+
+int baz(void) {
+    return 1;
+}
+
+int main(void) {
+    FOO(bar(), baz());
+    return 0;
+}
+
+// CHECK: [
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "FOO",
+// CHECK:     "IsObjectLike": false,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "( ( A ) , ( B ) )",
+// CHECK:     "IsDefinedAtGlobalScope": true,
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/is_any_argument_void.c:3:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/is_any_argument_void.c:3:28"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Invocation",
+// CHECK:     "Name": "FOO",
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/is_any_argument_void.c:3:9",
+// CHECK:     "InvocationLocation": "{{.*}}/Tests/is_any_argument_void.c:13:5",
+// CHECK:     "ASTKind": "Expr",
+// CHECK:     "TypeSignature": "int FOO(void A, int B)",
+// CHECK:     "InvocationDepth": 0,
+// CHECK:     "NumASTRoots": 1,
+// CHECK:     "NumArguments": 2,
+// CHECK:     "HasStringification": false,
+// CHECK:     "HasTokenPasting": false,
+// CHECK:     "HasAlignedArguments": true,
+// CHECK:     "HasSameNameAsOtherDeclaration": false,
+// CHECK:     "IsExpansionControlFlowStmt": false,
+// CHECK:     "DoesBodyReferenceMacroDefinedAfterMacro": false,
+// CHECK:     "DoesBodyReferenceDeclDeclaredAfterMacro": false,
+// CHECK:     "DoesBodyContainDeclRefExpr": false,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveLocalType": false,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveTypeDefinedAfterMacro": false,
+// CHECK:     "DoesAnyArgumentHaveSideEffects": false,
+// CHECK:     "DoesAnyArgumentContainDeclRefExpr": true,
+// CHECK:     "IsHygienic": true,
+// CHECK:     "IsICERepresentableByInt32": false,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "IsInvocationLocationValid": true,
+// CHECK:     "IsObjectLike": false,
+// CHECK:     "IsInvokedInMacroArgument": false,
+// CHECK:     "IsNamePresentInCPPConditional": false,
+// CHECK:     "IsExpansionICE": false,
+// CHECK:     "IsExpansionTypeNull": false,
+// CHECK:     "IsExpansionTypeAnonymous": false,
+// CHECK:     "IsExpansionTypeLocalType": false,
+// CHECK:     "IsExpansionTypeDefinedAfterMacro": false,
+// CHECK:     "IsExpansionTypeVoid": false,
+// CHECK:     "IsAnyArgumentTypeNull": false,
+// CHECK:     "IsAnyArgumentTypeAnonymous": false,
+// CHECK:     "IsAnyArgumentTypeLocalType": false,
+// CHECK:     "IsAnyArgumentTypeDefinedAfterMacro": false,
+// CHECK:     "IsAnyArgumentTypeVoid": true,
+// CHECK:     "IsInvokedWhereModifiableValueRequired": false,
+// CHECK:     "IsInvokedWhereAddressableValueRequired": false,
+// CHECK:     "IsInvokedWhereICERequired": false,
+// CHECK:     "IsInvokedWhereConstantExpressionRequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereModifiableValueRequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereAddressableValueRequired": false,
+// CHECK:     "IsAnyArgumentConditionallyEvaluated": false,
+// CHECK:     "IsAnyArgumentNeverExpanded": false,
+// CHECK:     "IsAnyArgumentNotAnExpression": false
+// CHECK:   }
+// CHECK: ]


### PR DESCRIPTION
Fix the `IsAnyArgument` property checks so that they are set to true if the property they check is true for any argument, not just the last one. Also adds a test to verify this behavior.

Closes #56 