### PR TITLE
Improve build portability of Maki 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,52 +8,25 @@ project(maki)
 # Set Clang version.
 set(MAKI_CLANG_VERSION 17)
 
-# Set this to a valid Clang installation dir.
-set(MAKI_LLVM_INSTALL_DIR
-    "/usr"
-    CACHE PATH "LLVM installation directory")
-
-# Check that the LLVM include directory is readable.
-set(MAKI_LLVM_INCLUDE_DIR
-    "${MAKI_LLVM_INSTALL_DIR}/include/llvm-${MAKI_CLANG_VERSION}")
-if(NOT IS_READABLE "${MAKI_LLVM_INCLUDE_DIR}")
-  message(
-    FATAL_ERROR "MAKI_LLVM_INSTALL_DIR (${MAKI_LLVM_INCLUDE_DIR}) is invalid.")
-endif()
-
-# Check that the Clang include directory is readable.
-set(MAKI_LLVM_CMAKE_FILE
-    "${MAKI_LLVM_INSTALL_DIR}/lib/cmake/clang-${MAKI_CLANG_VERSION}/ClangConfig.cmake"
-)
-if(NOT IS_READABLE "${MAKI_LLVM_CMAKE_FILE}")
-  message(
-    FATAL_ERROR "MAKI_LLVM_CMAKE_FILE (${MAKI_LLVM_CMAKE_FILE}) is invalid.")
-endif()
 
 # ===============================================================================
 # 1. LOAD CLANG CONFIGURATION For more:
 #   http://llvm.org/docs/CMake.html#embedding-llvm-in-your-project
 # ===============================================================================
 
-# Set LLVM and Clang installation directories so that find_package() can find
-# them.
-set(Clang_DIR "${MAKI_LLVM_INSTALL_DIR}/lib/cmake/clang-${MAKI_CLANG_VERSION}/")
-set(LLVM_DIR "${MAKI_LLVM_INSTALL_DIR}/lib/cmake/llvm-${MAKI_CLANG_VERSION}/")
 
-# Find Clang.
-find_package(Clang REQUIRED CONFIG)
+# Find Clang and LLVM.
+find_package(Clang ${MAKI_CLANG_VERSION} REQUIRED CONFIG)
+find_package(LLVM  REQUIRED CONFIG)
 
-# Sanity check. As Clang does not expose e.g. `CLANG_VERSION_MAJOR` through
-# AddClang.cmake, we have to use LLVM_VERSION_MAJOR instead. TODO: Revisit when
-# next version is released.
-if(NOT "${MAKI_CLANG_VERSION}" VERSION_EQUAL "${LLVM_VERSION_MAJOR}")
-  message(
-    FATAL_ERROR
-      "Found LLVM ${LLVM_VERSION_MAJOR}, but need LLVM ${MAKI_CLANG_VERSION}")
+# Set this variable for configuring the test suite and wrapper script.
+find_program(CLANG_C_COMPILER NAMES clang clang-${MAKI_CLANG_VERSION})
+
+if (NOT CLANG_C_COMPILER)
+  message(FATAL_ERROR "Clang executable not found")
 endif()
 
-message(STATUS "Found Clang ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using ClangConfig.cmake in: ${MAKI_LLVM_INSTALL_DIR}")
+message(STATUS "Found LLVM/Clang: ${LLVM_PACKAGE_VERSION}")
 
 message(STATUS "CLANG STATUS:")
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
@@ -61,8 +34,6 @@ message(STATUS "Includes (clang)    ${CLANG_INCLUDE_DIRS}")
 message(STATUS "Includes (llvm)     ${LLVM_INCLUDE_DIRS}")
 list(POP_BACK CMAKE_MESSAGE_INDENT)
 
-# Set this variable for configuring the test suite and wrapper script.
-set(CLANG_C_COMPILER "clang-${MAKI_CLANG_VERSION}")
 
 # ===============================================================================
 # 1. maki BUILD CONFIGURATION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,5 @@ option(MAKI_ENABLE_TESTING "Controls whether to build Maki's test suite" OFF)
 if(${MAKI_ENABLE_TESTING})
   enable_testing()
   # For LLVM lit test suite.
-  include(AddLLVM)
   add_subdirectory(test)
 endif()

--- a/README.md
+++ b/README.md
@@ -86,10 +86,18 @@ enabled and to run its test suite:
 
 ```bash
 cmake -S . -B build/ \
-    -DMAKI_ENABLE_TESTING=ON \
-    -DLLVM_EXTERNAL_LIT=<lit_path> \
-    -DFILECHECK_PATH=<filecheck_path>
+    -DMAKI_ENABLE_TESTING=ON 
 cmake --build build/ -t check-maki --parallel
+```
+
+Note: If lit and FileCheck are not in your PATH, you can specify their
+locations manually with the following command:
+
+```bash
+cmake -S . -B build/ \
+    -DMAKI_ENABLE_TESTING=ON \
+    -DLIT_PATH=<lit_path> \
+    -DFILECHECK_PATH=<filecheck_path> \
 ```
 
 Where `<lit_path>` and `<filecheck_path>` are the paths to your `lit` Python
@@ -120,9 +128,7 @@ Run the test suite:
 
 ```bash
 cmake -S . -B build/ \
-    -DMAKI_ENABLE_TESTING=ON \
-    -DLLVM_EXTERNAL_LIT=/usr/local/bin/lit \
-    -DFILECHECK_PATH=/lib/llvm-17/bin/FileCheck
+    -DMAKI_ENABLE_TESTING=ON
 cmake --build build/ -t check-maki --parallel
 ```
 

--- a/lib/IncludeCollector.cc
+++ b/lib/IncludeCollector.cc
@@ -4,7 +4,7 @@
 #include <clang/Basic/SourceLocation.h>
 #include <clang/Basic/SourceManager.h>
 #include <clang/Lex/Token.h>
-#include <llvm-17/llvm/ADT/StringRef.h>
+#include <llvm/ADT/StringRef.h>
 
 namespace maki {
 void IncludeCollector::InclusionDirective(

--- a/lib/IncludeCollector.hh
+++ b/lib/IncludeCollector.hh
@@ -6,7 +6,7 @@
 #include <clang/Basic/SourceManager.h>
 #include <clang/Lex/PPCallbacks.h>
 #include <clang/Lex/Token.h>
-#include <llvm-17/llvm/ADT/StringRef.h>
+#include <llvm/ADT/StringRef.h>
 #include <utility>
 #include <vector>
 

--- a/lib/JSONPrinter.cc
+++ b/lib/JSONPrinter.cc
@@ -1,7 +1,7 @@
 #include "JSONPrinter.hh"
 #include <initializer_list>
 #include <iomanip>
-#include <llvm-17/llvm/Support/raw_ostream.h>
+#include <llvm/Support/raw_ostream.h>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/lib/Logging.hh
+++ b/lib/Logging.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <llvm-17/llvm/Support/raw_ostream.h>
+#include <llvm/Support/raw_ostream.h>
 #include <string>
 
 namespace maki {

--- a/lib/MacroExpansionArgument.cc
+++ b/lib/MacroExpansionArgument.cc
@@ -3,7 +3,7 @@
 #include <clang/Basic/SourceManager.h>
 #include <clang/Basic/TokenKinds.h>
 #include <clang/Lex/Lexer.h>
-#include <llvm-17/llvm/Support/raw_ostream.h>
+#include <llvm/Support/raw_ostream.h>
 
 namespace maki {
 void MacroExpansionArgument::dumpASTInfo(llvm::raw_fd_ostream &OS,

--- a/lib/MacroExpansionArgument.hh
+++ b/lib/MacroExpansionArgument.hh
@@ -4,8 +4,8 @@
 #include <clang/Basic/LangOptions.h>
 #include <clang/Basic/SourceManager.h>
 #include <clang/Lex/Token.h>
-#include <llvm-17/llvm/ADT/StringRef.h>
-#include <llvm-17/llvm/Support/raw_ostream.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/raw_ostream.h>
 #include <vector>
 
 namespace maki {

--- a/lib/MacroExpansionNode.cc
+++ b/lib/MacroExpansionNode.cc
@@ -1,7 +1,7 @@
 #include "MacroExpansionNode.hh"
 #include <clang/Basic/LangOptions.h>
 #include <clang/Basic/SourceManager.h>
-#include <llvm-17/llvm/Support/raw_ostream.h>
+#include <llvm/Support/raw_ostream.h>
 #include <queue>
 #include <set>
 

--- a/lib/MacroExpansionNode.hh
+++ b/lib/MacroExpansionNode.hh
@@ -5,7 +5,7 @@
 #include <clang/Basic/SourceLocation.h>
 #include <clang/Lex/MacroInfo.h>
 #include <clang/Lex/Token.h>
-#include <llvm-17/llvm/ADT/StringRef.h>
+#include <llvm/ADT/StringRef.h>
 #include <set>
 #include <string>
 #include <vector>

--- a/lib/MakiASTConsumer.cc
+++ b/lib/MakiASTConsumer.cc
@@ -32,8 +32,8 @@
 #include <clang/Lex/Lexer.h>
 #include <clang/Lex/Preprocessor.h>
 #include <functional>
-#include <llvm-17/llvm/ADT/StringRef.h>
-#include <llvm-17/llvm/Support/Casting.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/Casting.h>
 #include <queue>
 #include <set>
 #include <string>

--- a/lib/MakiASTConsumer.hh
+++ b/lib/MakiASTConsumer.hh
@@ -8,7 +8,7 @@
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/Stmt.h>
 #include <clang/Frontend/CompilerInstance.h>
-#include <llvm-17/llvm/Support/Casting.h>
+#include <llvm/Support/Casting.h>
 
 namespace maki {
 class MakiASTConsumer : public clang::ASTConsumer {

--- a/lib/MakiAction.cc
+++ b/lib/MakiAction.cc
@@ -3,8 +3,8 @@
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendAction.h>
 #include <clang/Frontend/FrontendPluginRegistry.h>
-#include <llvm-17/llvm/ADT/StringRef.h>
-#include <llvm-17/llvm/Support/raw_ostream.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/raw_ostream.h>
 #include <string>
 
 namespace maki {

--- a/lib/MakiAction.hh
+++ b/lib/MakiAction.hh
@@ -4,7 +4,7 @@
 #include <clang/AST/ASTConsumer.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendAction.h>
-#include <llvm-17/llvm/ADT/StringRef.h>
+#include <llvm/ADT/StringRef.h>
 #include <memory>
 #include <string>
 #include <vector>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,25 +1,23 @@
-if(LLVM_EXTERNAL_LIT)
-  get_filename_component(LLVM_LIT_TOOLS_DIR "${LLVM_EXTERNAL_LIT}" DIRECTORY)
-  find_program(FILECHECK_PATH FileCheck HINTS "${LLVM_LIT_TOOLS_DIR}")
-else()
-  find_program(FILECHECK_PATH FileCheck)
-endif()
+find_program(FILECHECK_PATH NAMES FileCheck FileCheck-${LLVM_VERSION_MAJOR})
+message(STATUS "FileCheck found at ${FILECHECK_PATH}")
+find_program(LIT_PATH NAMES lit llvm-lit)
+message(STATUS "Lit found at ${LIT_PATH}")
 
-if(FILECHECK_PATH STREQUAL "FILECHECK_PATH-NOTFOUND")
+if(NOT FILECHECK_PATH)
   message(FATAL_ERROR "Could not find FileCheck")
 endif()
 
-configure_lit_site_cfg(
-  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
-  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py MAIN_CONFIG
-  ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py)
+if(NOT LIT_PATH)
+  message(FATAL_ERROR "Could not find LLVM LIT")
+endif()
+
+configure_file(lit.site.cfg.py.in lit.cfg.py @ONLY)
 
 set(MAKI_TEST_DEPENDS maki)
 
-add_lit_testsuite(check-maki "Running maki regression tests"
-                  ${CMAKE_CURRENT_BINARY_DIR} DEPENDS ${MAKI_TEST_DEPENDS})
-
-set_target_properties(check-maki PROPERTIES FOLDER "Tests")
-
-add_lit_testsuites(maki ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS
-                   ${MAKI_TEST_DEPENDS})
+add_custom_target(check-maki
+  COMMAND ${LIT_PATH} -s ${CMAKE_CURRENT_BINARY_DIR} 
+  DEPENDS ${MAKI_TEST_DEPENDS}
+  COMMENT "Running maki tests"
+  USES_TERMINAL
+)

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -2,49 +2,13 @@
 
 import sys
 
-config.host_triple = "@LLVM_HOST_TRIPLE@"
-config.target_triple = "@TARGET_TRIPLE@"
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
-config.llvm_lib_dir = "@LLVM_LIBS_DIR@"
-config.llvm_shlib_dir = "@SHLIBDIR@"
 config.llvm_shlib_ext = "@SHLIBEXT@"
-config.llvm_exe_ext = "@EXEEXT@"
-config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
-config.python_executable = "@PYTHON_EXECUTABLE@"
-config.gold_executable = "@GOLD_EXECUTABLE@"
-config.ld64_executable = "@LD64_EXECUTABLE@"
-config.enable_shared = @ENABLE_SHARED@
-config.enable_assertions = @ENABLE_ASSERTIONS@
-config.targets_to_build = "@TARGETS_TO_BUILD@"
-config.native_target = "@LLVM_NATIVE_ARCH@"
-config.llvm_bindings = "@LLVM_BINDINGS@".split(' ')
-config.host_os = "@HOST_OS@"
-config.host_cc = "@HOST_CC@"
-config.host_cxx = "@HOST_CXX@"
-config.enable_libcxx = "@LLVM_ENABLE_LIBCXX@"
-# Note: ldflags can contain double-quoted paths, so must use single quotes here.
-config.host_ldflags = '@HOST_LDFLAGS@'
-config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
-config.llvm_host_triple = '@LLVM_HOST_TRIPLE@'
-config.host_arch = "@HOST_ARCH@"
-config.maki_src_root = "@CMAKE_SOURCE_DIR@"
 config.maki_obj_root = "@CMAKE_BINARY_DIR@"
 config.file_check_path = "@FILECHECK_PATH@"
 config.clang_path = "@CLANG_C_COMPILER@"
-
-# Support substitution of the tools_dir with user parameters. This is
-# used when we can't determine the tool dir at configuration time.
-try:
-    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
-    config.llvm_lib_dir = config.llvm_lib_dir % lit_config.params
-    config.llvm_shlib_dir = config.llvm_shlib_dir % lit_config.params
-except KeyError:
-    e = sys.exc_info()[1]
-    key, = e.args
-    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
-
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)


### PR DESCRIPTION
This PR includes two main changes to Maki to make it build on more platforms in addition to the Docker image.
1. Change all includes to use llvm directory and not llvm-17 (`llvm-17/llvm/Support/Casting.h` -> `llvm/Support/Casting.h`)
2. Improve CMake build logic.

The CMake build logic improvements include:
* Use `find_program`/`find_package` where possible to find libraries such as LLVM and Clang, instead of constructing a non-portable path to their CMake config file.
* Simplify the logic of setting up the LIT test suite by not using LLVM's internal commands in AddLLVM for setting up LIT and using a custom target as described [here](https://medium.com/@mshockwave/using-llvm-lit-out-of-tree-5cddada85a78).
    * I'm not completely sure but I could not find any examples of out-of-tree projects using LLVM LIT in this manner, and I couldn't make the improvements work using the internal commands.
    * Find LIT and FileCheck automatically using find_program, which can still be overriden manually (updated the documentation to explain this).
    * Simplify `lit.site.cfg.py.in` by only keeping necessary variables for the test suite.
