### PR TITLE
Add property IsAnyArgumentExpandedWhereConstExprRequired

### DIFF
--- a/lib/MakiASTConsumer.cc
+++ b/lib/MakiASTConsumer.cc
@@ -454,6 +454,7 @@ void MakiASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
         bool IsAnyArgumentConditionallyEvaluated = false;
         bool IsAnyArgumentExpandedWhereAddressableValueRequired = false;
         bool IsAnyArgumentExpandedWhereModifiableValueRequired = false;
+        bool IsAnyArgumentExpandedWhereConstExprRequired = false;
         bool IsAnyArgumentNeverExpanded = false;
         bool IsAnyArgumentNotAnExpression = false;
         bool IsAnyArgumentTypeAnonymous = false;
@@ -939,6 +940,10 @@ void MakiASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
                         continue;
                     }
 
+                    IsAnyArgumentExpandedWhereConstExprRequired |=
+                        isDescendantOfNodeRequiringICE(Ctx, E) ||
+                        isDescendantOfNodeRequiringConstantExpression(Ctx, E);
+
                     std::string ArgTypeStr = "<Null>";
 
                     // Type information about arguments
@@ -1074,6 +1079,8 @@ void MakiASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
                 IsAnyArgumentExpandedWhereAddressableValueRequired },
               { "IsAnyArgumentConditionallyEvaluated",
                 IsAnyArgumentConditionallyEvaluated },
+              { "IsAnyArgumentExpandedWhereConstExprRequired",
+                IsAnyArgumentExpandedWhereConstExprRequired },
               { "IsAnyArgumentNeverExpanded", IsAnyArgumentNeverExpanded },
               { "IsAnyArgumentNotAnExpression",
                 IsAnyArgumentNotAnExpression } });

--- a/test/Tests/arguments_used_where_const_expr_needed.c
+++ b/test/Tests/arguments_used_where_const_expr_needed.c
@@ -1,0 +1,297 @@
+// RUN: maki %s -fplugin-arg-maki---no-system-macros -fplugin-arg-maki---no-builtin-macros -fplugin-arg-maki---no-invalid-macros | jq 'sort_by(.Kind, .DefinitionLocation, .InvocationLocation)' | FileCheck %s --color
+
+// COM: Argument used where constexpr required.
+#define ARG_IN_CASE(X) \
+    do {               \
+        switch (1) {   \
+        case X:        \
+            break;     \
+        }              \
+    } while (0)
+
+// COM: Argument used where constexpr required.
+#define ARG_IN_STATIC_INIT(X)   \
+    do {                        \
+        static int local_x = X; \
+        (void)local_x;          \
+    } while (0)
+
+// COM: Argument used where constexpr required.
+#define ARG_IN_ENUM_MEMBER_INIT(X) \
+    do {                           \
+        enum { LOCAL_A = X };      \
+    } while (0)
+
+// COM: Argument not used where constexpr required.
+#define ARG_IN_NON_STATIC_INIT(X) \
+    do {                          \
+        int local_x = X;          \
+        (void)local_x;            \
+    } while (0)
+
+int main(void) {
+    ARG_IN_CASE(1);
+    ARG_IN_STATIC_INIT(1);
+    ARG_IN_ENUM_MEMBER_INIT(1);
+    ARG_IN_NON_STATIC_INIT(1);
+    return 0;
+}
+
+// CHECK: [
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "ARG_IN_STATIC_INIT",
+// CHECK:     "IsObjectLike": false,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "do { static int local_x = X ; ( void ) local_x ; } while ( 0 )",
+// CHECK:     "IsDefinedAtGlobalScope": true,
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:13:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:17:16"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "ARG_IN_ENUM_MEMBER_INIT",
+// CHECK:     "IsObjectLike": false,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "do { enum { LOCAL_A = X } ; } while ( 0 )",
+// CHECK:     "IsDefinedAtGlobalScope": true,
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:20:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:23:16"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "ARG_IN_NON_STATIC_INIT",
+// CHECK:     "IsObjectLike": false,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "do { int local_x = X ; ( void ) local_x ; } while ( 0 )",
+// CHECK:     "IsDefinedAtGlobalScope": true,
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:26:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:30:16"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Definition",
+// CHECK:     "Name": "ARG_IN_CASE",
+// CHECK:     "IsObjectLike": false,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "Body": "do { switch ( 1 ) { case X : break ; } } while ( 0 )",
+// CHECK:     "IsDefinedAtGlobalScope": true,
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:4:9",
+// CHECK:     "EndDefinitionLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:10:16"
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Invocation",
+// CHECK:     "Name": "ARG_IN_STATIC_INIT",
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:13:9",
+// CHECK:     "InvocationLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:34:5",
+// CHECK:     "ASTKind": "Stmt",
+// CHECK:     "TypeSignature": "void ARG_IN_STATIC_INIT(int X)",
+// CHECK:     "InvocationDepth": 0,
+// CHECK:     "NumASTRoots": 1,
+// CHECK:     "NumArguments": 1,
+// CHECK:     "HasStringification": false,
+// CHECK:     "HasTokenPasting": false,
+// CHECK:     "HasAlignedArguments": true,
+// CHECK:     "HasSameNameAsOtherDeclaration": false,
+// CHECK:     "IsExpansionControlFlowStmt": false,
+// CHECK:     "DoesBodyReferenceMacroDefinedAfterMacro": false,
+// CHECK:     "DoesBodyReferenceDeclDeclaredAfterMacro": true,
+// CHECK:     "DoesBodyContainDeclRefExpr": true,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveLocalType": false,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveTypeDefinedAfterMacro": false,
+// CHECK:     "DoesAnyArgumentHaveSideEffects": false,
+// CHECK:     "DoesAnyArgumentContainDeclRefExpr": false,
+// CHECK:     "IsHygienic": true,
+// CHECK:     "IsICERepresentableByInt16": false,
+// CHECK:     "IsICERepresentableByInt32": false,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "IsInvocationLocationValid": true,
+// CHECK:     "IsObjectLike": false,
+// CHECK:     "IsInvokedInMacroArgument": false,
+// CHECK:     "IsNamePresentInCPPConditional": false,
+// CHECK:     "IsExpansionICE": false,
+// CHECK:     "IsExpansionTypeNull": false,
+// CHECK:     "IsExpansionTypeAnonymous": false,
+// CHECK:     "IsExpansionTypeLocalType": false,
+// CHECK:     "IsExpansionTypeDefinedAfterMacro": false,
+// CHECK:     "IsExpansionTypeVoid": false,
+// CHECK:     "IsExpansionTypeFunctionType": false,
+// CHECK:     "IsAnyArgumentTypeNull": false,
+// CHECK:     "IsAnyArgumentTypeAnonymous": false,
+// CHECK:     "IsAnyArgumentTypeLocalType": false,
+// CHECK:     "IsAnyArgumentTypeDefinedAfterMacro": false,
+// CHECK:     "IsAnyArgumentTypeVoid": false,
+// CHECK:     "IsAnyArgumentTypeFunctionType": false,
+// CHECK:     "IsInvokedWhereModifiableValueRequired": false,
+// CHECK:     "IsInvokedWhereAddressableValueRequired": false,
+// CHECK:     "IsInvokedWhereICERequired": false,
+// CHECK:     "IsInvokedWhereConstantExpressionRequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereModifiableValueRequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereAddressableValueRequired": false,
+// CHECK:     "IsAnyArgumentConditionallyEvaluated": false,
+// CHECK:     "IsAnyArgumentExpandedWhereConstExprRequired": true,
+// CHECK:     "IsAnyArgumentNeverExpanded": false,
+// CHECK:     "IsAnyArgumentNotAnExpression": false
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Invocation",
+// CHECK:     "Name": "ARG_IN_ENUM_MEMBER_INIT",
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:20:9",
+// CHECK:     "InvocationLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:35:5",
+// CHECK:     "ASTKind": "Stmt",
+// CHECK:     "TypeSignature": "void ARG_IN_ENUM_MEMBER_INIT(int X)",
+// CHECK:     "InvocationDepth": 0,
+// CHECK:     "NumASTRoots": 1,
+// CHECK:     "NumArguments": 1,
+// CHECK:     "HasStringification": false,
+// CHECK:     "HasTokenPasting": false,
+// CHECK:     "HasAlignedArguments": true,
+// CHECK:     "HasSameNameAsOtherDeclaration": false,
+// CHECK:     "IsExpansionControlFlowStmt": false,
+// CHECK:     "DoesBodyReferenceMacroDefinedAfterMacro": false,
+// CHECK:     "DoesBodyReferenceDeclDeclaredAfterMacro": false,
+// CHECK:     "DoesBodyContainDeclRefExpr": false,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveLocalType": false,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveTypeDefinedAfterMacro": false,
+// CHECK:     "DoesAnyArgumentHaveSideEffects": false,
+// CHECK:     "DoesAnyArgumentContainDeclRefExpr": false,
+// CHECK:     "IsHygienic": true,
+// CHECK:     "IsICERepresentableByInt16": false,
+// CHECK:     "IsICERepresentableByInt32": false,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "IsInvocationLocationValid": true,
+// CHECK:     "IsObjectLike": false,
+// CHECK:     "IsInvokedInMacroArgument": false,
+// CHECK:     "IsNamePresentInCPPConditional": false,
+// CHECK:     "IsExpansionICE": false,
+// CHECK:     "IsExpansionTypeNull": false,
+// CHECK:     "IsExpansionTypeAnonymous": false,
+// CHECK:     "IsExpansionTypeLocalType": false,
+// CHECK:     "IsExpansionTypeDefinedAfterMacro": false,
+// CHECK:     "IsExpansionTypeVoid": false,
+// CHECK:     "IsExpansionTypeFunctionType": false,
+// CHECK:     "IsAnyArgumentTypeNull": false,
+// CHECK:     "IsAnyArgumentTypeAnonymous": false,
+// CHECK:     "IsAnyArgumentTypeLocalType": false,
+// CHECK:     "IsAnyArgumentTypeDefinedAfterMacro": false,
+// CHECK:     "IsAnyArgumentTypeVoid": false,
+// CHECK:     "IsAnyArgumentTypeFunctionType": false,
+// CHECK:     "IsInvokedWhereModifiableValueRequired": false,
+// CHECK:     "IsInvokedWhereAddressableValueRequired": false,
+// CHECK:     "IsInvokedWhereICERequired": false,
+// CHECK:     "IsInvokedWhereConstantExpressionRequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereModifiableValueRequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereAddressableValueRequired": false,
+// CHECK:     "IsAnyArgumentConditionallyEvaluated": false,
+// CHECK:     "IsAnyArgumentExpandedWhereConstExprRequired": true,
+// CHECK:     "IsAnyArgumentNeverExpanded": false,
+// CHECK:     "IsAnyArgumentNotAnExpression": false
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Invocation",
+// CHECK:     "Name": "ARG_IN_NON_STATIC_INIT",
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:26:9",
+// CHECK:     "InvocationLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:36:5",
+// CHECK:     "ASTKind": "Stmt",
+// CHECK:     "TypeSignature": "void ARG_IN_NON_STATIC_INIT(int X)",
+// CHECK:     "InvocationDepth": 0,
+// CHECK:     "NumASTRoots": 1,
+// CHECK:     "NumArguments": 1,
+// CHECK:     "HasStringification": false,
+// CHECK:     "HasTokenPasting": false,
+// CHECK:     "HasAlignedArguments": true,
+// CHECK:     "HasSameNameAsOtherDeclaration": false,
+// CHECK:     "IsExpansionControlFlowStmt": false,
+// CHECK:     "DoesBodyReferenceMacroDefinedAfterMacro": false,
+// CHECK:     "DoesBodyReferenceDeclDeclaredAfterMacro": true,
+// CHECK:     "DoesBodyContainDeclRefExpr": true,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveLocalType": false,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveTypeDefinedAfterMacro": false,
+// CHECK:     "DoesAnyArgumentHaveSideEffects": false,
+// CHECK:     "DoesAnyArgumentContainDeclRefExpr": false,
+// CHECK:     "IsHygienic": true,
+// CHECK:     "IsICERepresentableByInt16": false,
+// CHECK:     "IsICERepresentableByInt32": false,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "IsInvocationLocationValid": true,
+// CHECK:     "IsObjectLike": false,
+// CHECK:     "IsInvokedInMacroArgument": false,
+// CHECK:     "IsNamePresentInCPPConditional": false,
+// CHECK:     "IsExpansionICE": false,
+// CHECK:     "IsExpansionTypeNull": false,
+// CHECK:     "IsExpansionTypeAnonymous": false,
+// CHECK:     "IsExpansionTypeLocalType": false,
+// CHECK:     "IsExpansionTypeDefinedAfterMacro": false,
+// CHECK:     "IsExpansionTypeVoid": false,
+// CHECK:     "IsExpansionTypeFunctionType": false,
+// CHECK:     "IsAnyArgumentTypeNull": false,
+// CHECK:     "IsAnyArgumentTypeAnonymous": false,
+// CHECK:     "IsAnyArgumentTypeLocalType": false,
+// CHECK:     "IsAnyArgumentTypeDefinedAfterMacro": false,
+// CHECK:     "IsAnyArgumentTypeVoid": false,
+// CHECK:     "IsAnyArgumentTypeFunctionType": false,
+// CHECK:     "IsInvokedWhereModifiableValueRequired": false,
+// CHECK:     "IsInvokedWhereAddressableValueRequired": false,
+// CHECK:     "IsInvokedWhereICERequired": false,
+// CHECK:     "IsInvokedWhereConstantExpressionRequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereModifiableValueRequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereAddressableValueRequired": false,
+// CHECK:     "IsAnyArgumentConditionallyEvaluated": false,
+// CHECK:     "IsAnyArgumentExpandedWhereConstExprRequired": false,
+// CHECK:     "IsAnyArgumentNeverExpanded": false,
+// CHECK:     "IsAnyArgumentNotAnExpression": false
+// CHECK:   },
+// CHECK:   {
+// CHECK:     "Kind": "Invocation",
+// CHECK:     "Name": "ARG_IN_CASE",
+// CHECK:     "DefinitionLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:4:9",
+// CHECK:     "InvocationLocation": "{{.*}}/Tests/arguments_used_where_const_expr_needed.c:33:5",
+// CHECK:     "ASTKind": "Stmt",
+// CHECK:     "TypeSignature": "void ARG_IN_CASE(int X)",
+// CHECK:     "InvocationDepth": 0,
+// CHECK:     "NumASTRoots": 1,
+// CHECK:     "NumArguments": 1,
+// CHECK:     "HasStringification": false,
+// CHECK:     "HasTokenPasting": false,
+// CHECK:     "HasAlignedArguments": true,
+// CHECK:     "HasSameNameAsOtherDeclaration": false,
+// CHECK:     "IsExpansionControlFlowStmt": true,
+// CHECK:     "DoesBodyReferenceMacroDefinedAfterMacro": false,
+// CHECK:     "DoesBodyReferenceDeclDeclaredAfterMacro": false,
+// CHECK:     "DoesBodyContainDeclRefExpr": false,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveLocalType": false,
+// CHECK:     "DoesSubexpressionExpandedFromBodyHaveTypeDefinedAfterMacro": false,
+// CHECK:     "DoesAnyArgumentHaveSideEffects": false,
+// CHECK:     "DoesAnyArgumentContainDeclRefExpr": false,
+// CHECK:     "IsHygienic": true,
+// CHECK:     "IsICERepresentableByInt16": false,
+// CHECK:     "IsICERepresentableByInt32": false,
+// CHECK:     "IsDefinitionLocationValid": true,
+// CHECK:     "IsInvocationLocationValid": true,
+// CHECK:     "IsObjectLike": false,
+// CHECK:     "IsInvokedInMacroArgument": false,
+// CHECK:     "IsNamePresentInCPPConditional": false,
+// CHECK:     "IsExpansionICE": false,
+// CHECK:     "IsExpansionTypeNull": false,
+// CHECK:     "IsExpansionTypeAnonymous": false,
+// CHECK:     "IsExpansionTypeLocalType": false,
+// CHECK:     "IsExpansionTypeDefinedAfterMacro": false,
+// CHECK:     "IsExpansionTypeVoid": false,
+// CHECK:     "IsExpansionTypeFunctionType": false,
+// CHECK:     "IsAnyArgumentTypeNull": false,
+// CHECK:     "IsAnyArgumentTypeAnonymous": false,
+// CHECK:     "IsAnyArgumentTypeLocalType": false,
+// CHECK:     "IsAnyArgumentTypeDefinedAfterMacro": false,
+// CHECK:     "IsAnyArgumentTypeVoid": false,
+// CHECK:     "IsAnyArgumentTypeFunctionType": false,
+// CHECK:     "IsInvokedWhereModifiableValueRequired": false,
+// CHECK:     "IsInvokedWhereAddressableValueRequired": false,
+// CHECK:     "IsInvokedWhereICERequired": false,
+// CHECK:     "IsInvokedWhereConstantExpressionRequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereModifiableValueRequired": false,
+// CHECK:     "IsAnyArgumentExpandedWhereAddressableValueRequired": false,
+// CHECK:     "IsAnyArgumentConditionallyEvaluated": false,
+// CHECK:     "IsAnyArgumentExpandedWhereConstExprRequired": true,
+// CHECK:     "IsAnyArgumentNeverExpanded": false,
+// CHECK:     "IsAnyArgumentNotAnExpression": false
+// CHECK:   }
+// CHECK: ]


### PR DESCRIPTION
Adds the property, `IsAnyArgumentExpandedWhereConstExprRequired`, which is true whenever a macro expansion expands an argument where a constant expression is required (e.g., in a static initializer, a case label, or an enum initializer).

Closes #75 