### PR TITLE
Only collect definition info

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,16 @@ analyze.
 
 Maki offers the following flags to modify its behavior:
 
-| Flag                  | Effect                                                                                                                  | Example invocation                           |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
-| `--builtin-macros`    | Maki will analyze macro definitions or invocations of compiler builtin macros (this is the default)                     | `maki -fplugin-arg-maki---builtin-macros`    |
-| `--no-builtin-macros` | Maki will not analyze macro definitions or invocations of compiler builtin macros                                       | `maki -fplugin-arg-maki---no-builtin-macros` |
-| `--system-macros`     | Maki will analyze macro definitions or invocations in system headers (this is the default)                              | `maki -fplugin-arg-maki---system-macros`     |
-| `--no-system-macros`  | Maki will not analyze macro definitions or invocations in system headers                                                | `maki -fplugin-arg-maki---no-system-macros`  |
-| `--invalid-macros`    | Maki will analyze macro definitions or invocations at invalid locations, e.g. on the command line (this is the default) | `maki -fplugin-arg-maki---invalid-macros`    |
-| `--no-invalid-macros` | Maki will not analyze macro definitions or invocations at invalid locations                                             | `maki -fplugin-arg-maki---no-invalid-macros` |
+| Flag                                | Effect                                                                                                                  | Example invocation                                         |
+|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
+| `--builtin-macros`                  | Maki will analyze macro definitions or invocations of compiler builtin macros (this is the default)                     | `maki -fplugin-arg-maki---builtin-macros`                  |
+| `--no-builtin-macros`               | Maki will not analyze macro definitions or invocations of compiler builtin macros                                       | `maki -fplugin-arg-maki---no-builtin-macros`               |
+| `--system-macros`                   | Maki will analyze macro definitions or invocations in system headers (this is the default)                              | `maki -fplugin-arg-maki---system-macros`                   |
+| `--no-system-macros`                | Maki will not analyze macro definitions or invocations in system headers                                                | `maki -fplugin-arg-maki---no-system-macros`                |
+| `--invalid-macros`                  | Maki will analyze macro definitions or invocations at invalid locations, e.g. on the command line (this is the default) | `maki -fplugin-arg-maki---invalid-macros`                  |
+| `--no-invalid-macros`               | Maki will not analyze macro definitions or invocations at invalid locations                                             | `maki -fplugin-arg-maki---no-invalid-macros`               |
+| `--only-collect-definition-info`    | Maki will only print macro definition locations                                                                         | `maki -fplugin-arg-maki---only-collect-definition-info`    |
+| `--no-only-collect-definition-info` | Maki will perform its normal analyses                                                                                   | `maki -fplugin-arg-maki---no-only-collect-definition-info` |
 
 ## Testing
 

--- a/lib/MakiAction.cc
+++ b/lib/MakiAction.cc
@@ -29,6 +29,10 @@ bool MakiAction::ParseArgs(const clang::CompilerInstance &CI,
             Flags.ProcessMacrosAtInvalidLocations = true;
         } else if ("--no-invalid-macros" == arg) {
             Flags.ProcessMacrosAtInvalidLocations = false;
+        }  else if ("--only-collect-definition-info" == arg) {
+            Flags.OnlyCollectDefinitionInfo = true;
+        } else if ("--no-only-collect-definition-info" == arg) {
+            Flags.OnlyCollectDefinitionInfo = false;
         } else {
             llvm::errs() << "Error: Unrecognized argument: " << arg << '\n';
             return false;

--- a/lib/MakiFlags.hh
+++ b/lib/MakiFlags.hh
@@ -11,6 +11,7 @@ struct MakiFlags {
     bool ProcessBuiltinMacros = true;
     bool ProcessMacrosInSystemHeaders = true;
     bool ProcessMacrosAtInvalidLocations = true;
+    bool OnlyCollectDefinitionInfo = false;
 };
 
 std::pair<bool, std::string> tryGetFullSourceLoc(clang::SourceManager &SM,


### PR DESCRIPTION
Adds a command line option to only print macro definition locations without doing Maki's full analysis in order to quickly collect basic macro definition information.

Closes #79 