### PR TITLE
Collect invoked macro definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,17 @@ analyze.
 
 Maki offers the following flags to modify its behavior:
 
-| Flag                                | Effect                                                                                                                  | Example invocation                                         |
-|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
-| `--builtin-macros`                  | Maki will analyze macro definitions or invocations of compiler builtin macros (this is the default)                     | `maki -fplugin-arg-maki---builtin-macros`                  |
-| `--no-builtin-macros`               | Maki will not analyze macro definitions or invocations of compiler builtin macros                                       | `maki -fplugin-arg-maki---no-builtin-macros`               |
-| `--system-macros`                   | Maki will analyze macro definitions or invocations in system headers (this is the default)                              | `maki -fplugin-arg-maki---system-macros`                   |
-| `--no-system-macros`                | Maki will not analyze macro definitions or invocations in system headers                                                | `maki -fplugin-arg-maki---no-system-macros`                |
-| `--invalid-macros`                  | Maki will analyze macro definitions or invocations at invalid locations, e.g. on the command line (this is the default) | `maki -fplugin-arg-maki---invalid-macros`                  |
-| `--no-invalid-macros`               | Maki will not analyze macro definitions or invocations at invalid locations                                             | `maki -fplugin-arg-maki---no-invalid-macros`               |
-| `--only-collect-definition-info`    | Maki will only print macro definition locations                                                                         | `maki -fplugin-arg-maki---only-collect-definition-info`    |
-| `--no-only-collect-definition-info` | Maki will perform its normal analyses                                                                                   | `maki -fplugin-arg-maki---no-only-collect-definition-info` |
+| Flag                                     | Effect                                                                                                                  | Example invocation                                           |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `--builtin-macros`                       | Maki will analyze macro definitions or invocations of compiler builtin macros (this is the default)                     | `maki -fplugin-arg-maki---builtin-macros`                    |
+| `--no-builtin-macros`                    | Maki will not analyze macro definitions or invocations of compiler builtin macros                                       | `maki -fplugin-arg-maki---no-builtin-macros`                 |
+| `--system-macros`                        | Maki will analyze macro definitions or invocations in system headers (this is the default)                              | `maki -fplugin-arg-maki---system-macros`                     |
+| `--no-system-macros`                     | Maki will not analyze macro definitions or invocations in system headers                                                | `maki -fplugin-arg-maki---no-system-macros`                  |
+| `--invalid-macros`                       | Maki will analyze macro definitions or invocations at invalid locations, e.g. on the command line (this is the default) | `maki -fplugin-arg-maki---invalid-macros`                    |
+| `--no-invalid-macros`                    | Maki will not analyze macro definitions or invocations at invalid locations                                             | `maki -fplugin-arg-maki---no-invalid-macros`                 |
+| `--only-collect-definition-info=no`      | Maki will perform its normal analyses                                                                                   | `maki -fplugin-arg-maki---only-collect-definition-info=no`   |
+| `--only-collect-definition-info=all`     | Maki will only report definitions of macros                                                                             | `maki -fplugin-arg-maki---only-collect-definition-info=all`  |
+| `--only-collect-definition-info=invoked` | Maki will only report definitions of invoked macros                                                                     | `maki -fplugin-arg-maki---only-collect-definition-info=none` |
 
 ## Testing
 
@@ -88,7 +89,7 @@ enabled and to run its test suite:
 
 ```bash
 cmake -S . -B build/ \
-    -DMAKI_ENABLE_TESTING=ON 
+    -DMAKI_ENABLE_TESTING=ON
 cmake --build build/ -t check-maki --parallel
 ```
 
@@ -137,18 +138,18 @@ cmake --build build/ -t check-maki --parallel
 Note: If you are on an AMD64 architecture, please follow these steps:
 
 1. Add the following line to the beginning of the Dockerfile:
-```#!/bin/bash```
+   `#!/bin/bash`
 
 2. Change the now second line of the docker file from:
-```FROM ubuntu:22.04```
-to:
-```FROM --platform=linux/amd64 ubuntu:22.04```
+   `FROM ubuntu:22.04`
+   to:
+   `FROM --platform=linux/amd64 ubuntu:22.04`
 
 3. Build the Docker image with the following command:
-```docker build --platform linux/amd64  -t maki:1.0 .```
+   `docker build --platform linux/amd64  -t maki:1.0 .`
 
 4. Run the Docker image:
-```docker run --platform linux/amd64 --name maki-container -it maki:1.0```
+   `docker run --platform linux/amd64 --name maki-container -it maki:1.0`
 
 ## Contributing
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(maki
     DefinitionInfoCollector.cc
     ExpansionMatchHandler.cc
     IncludeCollector.cc
+    InvokedDefinitionInfoCollector.cc
     JSONPrinter.cc
     MacroExpansionArgument.cc
     MacroExpansionNode.cc

--- a/lib/InvokedDefinitionInfoCollector.cc
+++ b/lib/InvokedDefinitionInfoCollector.cc
@@ -6,7 +6,8 @@ namespace maki {
 InvokedDefinitionInfoCollector::InvokedDefinitionInfoCollector(
     clang::ASTContext &Ctx, MakiFlags Flags)
     : SM(Ctx.getSourceManager())
-    , LO(Ctx.getLangOpts()) {
+    , LO(Ctx.getLangOpts())
+    , Flags(Flags) {
 }
 
 void InvokedDefinitionInfoCollector::MacroExpands(

--- a/lib/InvokedDefinitionInfoCollector.cc
+++ b/lib/InvokedDefinitionInfoCollector.cc
@@ -1,0 +1,24 @@
+#include "InvokedDefinitionInfoCollector.hh"
+#include "MakiFlags.hh"
+#include <clang/AST/ASTContext.h>
+
+namespace maki {
+InvokedDefinitionInfoCollector::InvokedDefinitionInfoCollector(
+    clang::ASTContext &Ctx, MakiFlags Flags)
+    : SM(Ctx.getSourceManager())
+    , LO(Ctx.getLangOpts()) {
+}
+
+void InvokedDefinitionInfoCollector::MacroExpands(
+    const clang::Token &MacroNameTok, const clang::MacroDefinition &MD,
+    clang::SourceRange Range, const clang::MacroArgs *Args) {
+    auto BeginSpellingLocation = SM.getSpellingLoc(Range.getBegin());
+    if (shouldSkipMacroDefinition(SM, Flags, MD) ||
+        shouldSkipMacroInvocation(SM, Flags, MD, BeginSpellingLocation)) {
+        return;
+    }
+
+    auto Name = MacroNameTok.getIdentifierInfo()->getName();
+    MacroNamesInfos[Name].insert(MD.getMacroInfo());
+}
+} // namespace maki

--- a/lib/InvokedDefinitionInfoCollector.hh
+++ b/lib/InvokedDefinitionInfoCollector.hh
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "MakiFlags.hh"
+#include <clang/AST/ASTContext.h>
+#include <clang/Basic/LangOptions.h>
+#include <clang/Basic/SourceManager.h>
+#include <clang/Lex/MacroInfo.h>
+#include <clang/Lex/PPCallbacks.h>
+#include <clang/Lex/Preprocessor.h>
+#include <llvm-17/llvm/ADT/StringRef.h>
+#include <map>
+#include <set>
+
+namespace maki {
+class InvokedDefinitionInfoCollector : public clang::PPCallbacks {
+private:
+    clang::SourceManager &SM;
+    const clang::LangOptions &LO;
+    MakiFlags Flags;
+
+public:
+    std::map<llvm::StringRef, std::set<clang::MacroInfo *>> MacroNamesInfos;
+
+    InvokedDefinitionInfoCollector(clang::ASTContext &Ctx, MakiFlags Flags);
+
+    void MacroExpands(const clang::Token &MacroNameTok,
+                      const clang::MacroDefinition &MD,
+                      clang::SourceRange Range,
+                      const clang::MacroArgs *Args) override;
+};
+} // namespace maki

--- a/lib/MakiASTConsumer.hh
+++ b/lib/MakiASTConsumer.hh
@@ -2,6 +2,7 @@
 
 #include "DefinitionInfoCollector.hh"
 #include "IncludeCollector.hh"
+#include "InvokedDefinitionInfoCollector.hh"
 #include "MacroForest.hh"
 #include "MakiFlags.hh"
 #include <clang/AST/ASTConsumer.h>
@@ -16,6 +17,7 @@ private:
     maki::MacroForest *MF;
     maki::IncludeCollector *IC;
     maki::DefinitionInfoCollector *DC;
+    maki::InvokedDefinitionInfoCollector *IDC;
     MakiFlags Flags;
 
 public:

--- a/lib/MakiAction.cc
+++ b/lib/MakiAction.cc
@@ -1,5 +1,6 @@
 #include "MakiAction.hh"
 #include "MakiASTConsumer.hh"
+#include "MakiFlags.hh"
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendAction.h>
 #include <clang/Frontend/FrontendPluginRegistry.h>
@@ -17,6 +18,9 @@ MakiAction::CreateASTConsumer(clang::CompilerInstance &CI,
 bool MakiAction::ParseArgs(const clang::CompilerInstance &CI,
                            const std::vector<std::string> &args) {
     for (const auto &arg : args) {
+        std::string OnlyCollectDefinitionInfoArg =
+            "--only-collect-definition-info";
+
         if ("--system-macros" == arg) {
             Flags.ProcessMacrosInSystemHeaders = true;
         } else if ("--no-system-macros" == arg) {
@@ -29,10 +33,27 @@ bool MakiAction::ParseArgs(const clang::CompilerInstance &CI,
             Flags.ProcessMacrosAtInvalidLocations = true;
         } else if ("--no-invalid-macros" == arg) {
             Flags.ProcessMacrosAtInvalidLocations = false;
-        }  else if ("--only-collect-definition-info" == arg) {
-            Flags.OnlyCollectDefinitionInfo = true;
-        } else if ("--no-only-collect-definition-info" == arg) {
-            Flags.OnlyCollectDefinitionInfo = false;
+        } else if (OnlyCollectDefinitionInfoArg ==
+                   arg.substr(0, OnlyCollectDefinitionInfoArg.length())) {
+            std::size_t equals_sign_index = arg.find("=");
+            if (std::string::npos == equals_sign_index) {
+                llvm::errs()
+                    << "Error: Expected equals sign followed by 'no', 'all', or 'invoked'\n";
+                return false;
+            }
+            std::string value = arg.substr(
+                equals_sign_index + 1, arg.length() - equals_sign_index - 1);
+            if ("no" == value) {
+                Flags.OnlyCollectDefinitionInfo = NO;
+            } else if ("all" == value) {
+                Flags.OnlyCollectDefinitionInfo = ALL;
+            } else if ("invoked" == value) {
+                Flags.OnlyCollectDefinitionInfo = INVOKED;
+            } else {
+                llvm::errs()
+                    << "Error: Expected equals sign followed by 'no', 'all', or 'invoked'\n";
+                return false;
+            }
         } else {
             llvm::errs() << "Error: Unrecognized argument: " << arg << '\n';
             return false;

--- a/lib/MakiFlags.hh
+++ b/lib/MakiFlags.hh
@@ -7,11 +7,17 @@
 #include <utility>
 
 namespace maki {
+enum OnlyCollectDefinitionInfoFlags {
+    NO,
+    ALL,
+    INVOKED
+};
+
 struct MakiFlags {
     bool ProcessBuiltinMacros = true;
     bool ProcessMacrosInSystemHeaders = true;
     bool ProcessMacrosAtInvalidLocations = true;
-    bool OnlyCollectDefinitionInfo = false;
+    OnlyCollectDefinitionInfoFlags OnlyCollectDefinitionInfo = NO;
 };
 
 std::pair<bool, std::string> tryGetFullSourceLoc(clang::SourceManager &SM,


### PR DESCRIPTION
Adds three variants to Maki's `only-collect-definition-info' flag to control Maki's behavior:

- `none`: Don't collect definitions and perform normal analyses. This is the default.
- `all`: Collect all macro definitions and don't perform analyses.
- `invoked`: Collect definitions of macros invoked at least once, and don't perform analyses.

These additions are a bit of a shim right now and can likely be refactored to merge the new `InvokedDefinitionsInfoCollector` class with the existing `DefinitionInfoCollector` class.

Closes #81 